### PR TITLE
Fix path reference to ember.js in HjsTemplate

### DIFF
--- a/lib/ember-rails/hjs_template.rb
+++ b/lib/ember-rails/hjs_template.rb
@@ -34,7 +34,7 @@ module EmberRails
       end
 
       def ember
-        [ "ember-precompiler.js", "ember.min.js" ].map do |name|
+        [ "ember-precompiler.js", "ember.js" ].map do |name|
           File.read(File.expand_path(File.join(__FILE__, "..", "..", "..", "vendor/assets/javascripts/#{name}")))
         end.join("\n")
       end


### PR DESCRIPTION
ember.min.js does not exist in `vendor/assets/javascripts/`, but ember.js does.
