### PR TITLE
Include support for .handlebars extension

### DIFF
--- a/lib/ember-rails.rb
+++ b/lib/ember-rails.rb
@@ -9,4 +9,5 @@ module EmberRails
   # an asset file having the extension ".hjs" is processed
   # by the asset pipeline and converted to javascript code.
   Sprockets.register_engine '.hjs', HjsTemplate
+  Sprockets.register_engine '.handlebars', HjsTemplate
 end


### PR DESCRIPTION
Apparently, @wycats (the creator of Handlebars) prefers the .handlebars file extension:

https://twitter.com/#!/dgeb/status/157591512136433664

I've also seen .hbs used, but I'm not sure if you want to support all three.
