### PR TITLE
Add missing require.

### DIFF
--- a/lib/ember-rails.rb
+++ b/lib/ember-rails.rb
@@ -1,3 +1,4 @@
+require 'sprockets'
 require 'sprockets/engines'
 require 'ember-rails/hjs_template'
 


### PR DESCRIPTION
Ember-rails currently fails with

```
/Users/delwyn/code/ember-rails/lib/ember-rails.rb:11:in `<module:EmberRails>': undefined method `register_engine' for Sprockets:Module (NoMethodError)
```

Requiring sprockets fixes this.

Thanks
