### PR TITLE
Adding ember:install generator

### DIFF
--- a/lib/generators/ember/install/install_generator.rb
+++ b/lib/generators/ember/install/install_generator.rb
@@ -2,18 +2,19 @@ module Ember
   module Generators
     class InstallGenerator < Rails::Generators::Base
       source_root File.expand_path("../templates", __FILE__)
+      argument :application_name, type: :string, default: "app"
 
       desc "Installs ember.js with a default folder layout in app/assets/javascripts/ember"
 
-      class_option :skip_git, :type => :boolean, :aliases => "-g",
-                   :default => false,  :desc => "Skip Git keeps"
+      class_option :skip_git, type: :boolean, aliases: "-g",
+                   default: false,  desc: "Skip Git keeps"
 
       def inject_ember
         inject_into_file("app/assets/javascripts/application.js", 
                          before: "//= require_tree") do
           dependencies = [
             "//= require ember",
-            "//= require ember/app"
+            "//= require ember/#{application_name.underscore}"
           ]
           dependencies.join("\n").concat("\n")
         end
@@ -27,7 +28,7 @@ module Ember
       end
 
       def create_app_file
-        template "app.coffee", "app/assets/javascripts/ember/app.js.coffee"
+        template "app.coffee", "app/assets/javascripts/ember/#{application_name.underscore}.js.coffee"
       end
     end
   end

--- a/lib/generators/ember/install/templates/app.coffee
+++ b/lib/generators/ember/install/templates/app.coffee
@@ -5,4 +5,4 @@
 #= require_tree ./helpers
 #= require_tree ./templates
 
-window.App = Ember.Application.create()
+window.<%= application_name.camelize %> = Ember.Application.create()


### PR DESCRIPTION
Now, you can use ember:install to install ember.js and generate a default folder layout in app/assets/javascripts/ember

```
francesco@notebook:~/emberails$ rails g ember:install power
      insert  app/assets/javascripts/application.js
      create  app/assets/javascripts/ember/models
      create  app/assets/javascripts/ember/models/.gitkeep
      create  app/assets/javascripts/ember/controllers
      create  app/assets/javascripts/ember/controllers/.gitkeep
      create  app/assets/javascripts/ember/views
      create  app/assets/javascripts/ember/views/.gitkeep
      create  app/assets/javascripts/ember/helpers
      create  app/assets/javascripts/ember/helpers/.gitkeep
      create  app/assets/javascripts/ember/templates
      create  app/assets/javascripts/ember/templates/.gitkeep
      create  app/assets/javascripts/ember/power.js.coffee
```
