### PR TITLE
Update to README to use current bootstrap generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dev copies like so:
 ## Architecture
 
 Ember does not require an organized file structure. However, ember-rails allows you 
-to use `rails g ember_rails:bootstrap` to create the following directory structure under `app/assets/javascripts/ember`:
+to use `rails g ember:bootstrap` to create the following directory structure under `app/assets/javascripts/ember`:
 
     controllers/
     helpers/


### PR DESCRIPTION
The new bootstrap generator is `rails g ember:bootstrap` and not `rails g ember_rails:bootstrap`
