### PR TITLE
`App.store` should be an instance

### DIFF
--- a/lib/generators/templates/store.js
+++ b/lib/generators/templates/store.js
@@ -1,4 +1,4 @@
-<%= application_name.camelize %>.Store = DS.Store.extend({
+<%= application_name.camelize %>.store = DS.Store.create({
   revision: 4,
   adapter: DS.RESTAdapter.create()
 });


### PR DESCRIPTION
I guess `App.Store` is meant to be automatically instanced at `App.store` on `App.initialize` but even with the current ember.js master this doesn't work.
