### PR TITLE
Default to ES5 for Closure Compiler

### DIFF
--- a/lib/ember_rails.rb
+++ b/lib/ember_rails.rb
@@ -30,6 +30,12 @@ module Ember
         config.ember.handlebars_location = location_for(app, "handlebars.js")
       end
 
+      initializer "ember_rails.es5_default", :group => :all do |app|
+        if defined?(Closure::Compiler) && app.config.assets.js_compressor == :closure
+          Closure::Compiler::DEFAULT_OPTIONS[:language_in] = 'ECMASCRIPT5'
+        end
+      end
+
       def location_for(app, file)
         path = app.config.assets.paths.find do |dir|
           Pathname.new(dir).join(file).exist?


### PR DESCRIPTION
As discussed in emberjs/ember.js#957, Closure Compiler finds invalid Javascript in Ember when running in its default ES3 mode.  This defaults Closure Compiler to run in ES5 mode.
