### PR TITLE
Trivial change to leftover reference to generated 'states' directory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ to use `rails g ember:bootstrap` to create the following directory structure und
     controllers/
     helpers/
     models/
-    states/
+    routes/
     templates/
     views/
 


### PR DESCRIPTION
The README still referenced generating a `states` directory when running `rails g ember:bootstrap`. Replace it with reference to `routes`.
