### PR TITLE
Require rails in ember_rails

### DIFF
--- a/lib/ember_rails.rb
+++ b/lib/ember_rails.rb
@@ -1,3 +1,4 @@
+require 'rails'
 require 'ember/rails/version'
 require 'ember/version'
 require 'ember/handlebars/version'


### PR DESCRIPTION
This is not normally necessary in Rails itself, but I've needed to
interactively pry into ember-rails.

"require 'rails'" seems to be the correct way to require railties:
https://github.com/rails/rails/tree/master/railties/lib
