### PR TITLE
require_tree . should come before any code

### DIFF
--- a/lib/generators/ember/bootstrap_generator.rb
+++ b/lib/generators/ember/bootstrap_generator.rb
@@ -22,10 +22,12 @@ module Ember
             "//= require ember",
             "//= require ember-data",
             "//= require_self",
-            "//= require #{application_name.underscore}",
-            "#{application_name.camelize} = Ember.Application.create();"
+            "//= require #{application_name.underscore}"
           ]
           dependencies.join("\n").concat("\n")
+        end
+        inject_into_file(application_file, :after => "//= require_tree .") do
+          "\n#{application_name.camelize} = Ember.Application.create();"
         end
       end
 


### PR DESCRIPTION
Currently, upon running `rails g ember:bootstrap` the `Ember.Application.create()` line is inserted **before** the `require_tree .` directive, which results in the latter being ignored.

This PR changes the ordering so that `Ember.Application.create()` is inserted the line **after** `require_tree .`
