### PR TITLE
Stub event property of fake jQuery

### DIFF
--- a/lib/ember/handlebars/assets/ember-precompiler.js
+++ b/lib/ember/handlebars/assets/ember-precompiler.js
@@ -18,6 +18,7 @@ var jQuery = window.jQuery = function() { return jQuery; };
 jQuery.ready = function() { return jQuery; };
 jQuery.inArray = function() { return jQuery; };
 jQuery.jquery = "1.7.2";
+jQuery.event = {fixHooks: {}};
 
 // Precompiler
 var EmberRails = {


### PR DESCRIPTION
Without this line, when compiling the default, dummy handlebars template against ember HEAD I get the error: Cannot read property 'fixHooks' of undefined. It appears that this asset step requires those properties to be set.
