### PR TITLE
rails initializer fix

### DIFF
--- a/lib/ember/rails/engine.rb
+++ b/lib/ember/rails/engine.rb
@@ -14,9 +14,9 @@ module Ember
         require 'ember/filters/slim' if defined? Slim
         require 'ember/filters/haml' if defined? Haml
 
-        app.assets.register_engine '.handlebars', Ember::Handlebars::Template
-        app.assets.register_engine '.hbs', Ember::Handlebars::Template
-        app.assets.register_engine '.hjs', Ember::Handlebars::Template
+        app.config.assets.register_engine '.handlebars', Ember::Handlebars::Template
+        app.config.assets.register_engine '.hbs', Ember::Handlebars::Template
+        app.config.assets.register_engine '.hjs', Ember::Handlebars::Template
       end
     end
   end


### PR DESCRIPTION
I believe it needs to be `app.config.assets` instead of `app.assets`. It fails otherwise

If this is merged, you might want to push a new gem release asap as 0.7.0 seems broken on Rails 3.2

Thanks!
