### PR TITLE
Generator template store.js fix 

### DIFF
--- a/lib/generators/templates/store.js
+++ b/lib/generators/templates/store.js
@@ -1,4 +1,4 @@
-<%= application_name.camelize %>.Store = DS.Store.extend({
+<%= application_name.camelize %>.Store = DS.Store.create({
   revision: 4,
   adapter: DS.RESTAdapter.create()
 });


### PR DESCRIPTION
store.js template needs to use `DS.Store.create()` instead of `DS.Store.extend()`

Otherwise, adapter functions dont' exist on the `<App>.store` object.
