### PR TITLE
Support 'belongsTo' relation in scaffold generator

### DIFF
--- a/lib/generators/templates/model.js
+++ b/lib/generators/templates/model.js
@@ -1,5 +1,11 @@
 <%= application_name.camelize %>.<%= class_name %> = DS.Model.extend({
 <% attributes.each_index do |idx| -%>
-  <%= attributes[idx][:name].camelize(:lower) %>: DS.attr('<%= attributes[idx][:type] %>')<% if (idx < attributes.length-1) %>,<% end %>
+  <%= attributes[idx][:name].camelize(:lower) %>: <%=
+  if %w(references belongs_to).member?(attributes[idx][:type])
+    "DS.belongsTo('%s.%s')" % [application_name.camelize, attributes[idx][:name].camelize]
+  else
+    "DS.attr('%s')" % attributes[idx][:type]
+  end
+  %><% if (idx < attributes.length-1) %>,<% end %>
 <% end -%>
 });


### PR DESCRIPTION
I want to use 'references' in scaffold generator.

When the following command run, I hope that the model was generated validly.
`$ rails generate scaffold comment post:reference body:text`

expected:

``` js
App.Comment = DS.Model.extend({
  post: DS.belongsTo('App.Post'),
  body: DS.attr('string')
});
```

But actual:

``` js
App.Comment = DS.Model.extend({
  post: DS.attr('references'),
  body: DS.attr('string')
});
```
