### PR TITLE
Updated install_generator to call 'rake dist'

### DIFF
--- a/lib/generators/ember/install_generator.rb
+++ b/lib/generators/ember/install_generator.rb
@@ -28,10 +28,10 @@ module Ember
           end
 
           Dir.chdir git_root do
-            say_status("building", "bundle && bundle exec rake", :green)
+            say_status("building", "bundle && bundle exec rake dist", :green)
             Bundler.with_clean_env do
               cmd "bundle --gemfile #{gem_file}"
-              cmd %{BUNDLE_GEMFILE="#{gem_file}" bundle exec rake}
+              cmd %{BUNDLE_GEMFILE="#{gem_file}" bundle exec rake dist}
             end
           end
 


### PR DESCRIPTION
Reason: Ember changed its default rake task to 'test'.
