### PR TITLE
Improved templates root path matching

### DIFF
--- a/lib/ember/handlebars/template.rb
+++ b/lib/ember/handlebars/template.rb
@@ -76,7 +76,7 @@ module Ember
         root = configuration.templates_root
 
         unless root.blank?
-          path.gsub!(/^#{Regexp.quote(root)}\/?/, '')
+          path.gsub!(/^(.*\/)*?#{Regexp.quote(root)}\/?/, '')
         end
 
         path = path.split('/')

--- a/test/hjstemplate_test.rb
+++ b/test/hjstemplate_test.rb
@@ -54,6 +54,17 @@ class HjsTemplateTest < ActionController::IntegrationTest
     end
   end
 
+  test "should allow partial templates_root matching" do
+    with_template_root("templates") do
+      t = Ember::Handlebars::Template.new {}
+      path = t.send(:template_path, 'app/templates/example')
+      assert_equal 'example', path
+
+      path = t.send(:template_path, 'admin/templates/admin_example')
+      assert_equal 'admin_example', path
+    end
+  end
+
   test "asset pipeline should serve template" do
     get "/assets/templates/test.js"
     assert_response :success


### PR DESCRIPTION
With this change we can have nicely isolated ember applications inside a single rails app.
For example, in your assets/javascripts you could have:
- frontend.js
- admin.js
- frontend/templates/application.handlebars
- admin/templates/application.handlebars

And in each application, its template would be available at `application` path, instead of `[app_name]/templates/application` (assuming that config.handlebars.templates_root == 'templates').
