### PR TITLE
Supporting multiple template roots

### DIFF
--- a/lib/ember/handlebars/template.rb
+++ b/lib/ember/handlebars/template.rb
@@ -75,8 +75,14 @@ module Ember
       def template_path(path)
         root = configuration.templates_root
 
-        unless root.blank?
-          path.gsub!(/^#{Regexp.quote(root)}\/?/, '')
+        if root.kind_of? Array
+          root.each do |root|
+            path.gsub!(/^#{Regexp.quote(root)}\//, '')
+          end
+        else
+          unless root.empty?
+            path.gsub!(/^#{Regexp.quote(root)}\/?/, '')
+          end
         end
 
         path = path.split('/')

--- a/test/hjstemplate_test.rb
+++ b/test/hjstemplate_test.rb
@@ -54,6 +54,18 @@ class HjsTemplateTest < ActionController::IntegrationTest
     end
   end
 
+  test "should strip different template roots" do
+    with_template_root(["templates", "templates_mobile"]) do
+      t = Ember::Handlebars::Template.new {}
+      #old, handlebars.templates_root = handlebars.templates_root, 'app/templates'
+      path = t.send(:template_path, 'templates/app/example')
+      assert path == 'app/example', path
+
+      path = t.send(:template_path, 'templates_mobile/app/example')
+      assert path == 'app/example', path
+    end
+  end
+
   test "asset pipeline should serve template" do
     get "/assets/templates/test.js"
     assert_response :success


### PR DESCRIPTION
Hi we needed to have a extra templates folder for a mobile version so i patched the gem to support stripping multiple root folders from the templates_path.

we now can have app/assets/javascripts/templates and
we now can have app/assets/javascripts/templates_mobile
where both templates and templates_mobile get stripped out of the path when compiling the templates.

in our application.rb we use
config.handlebars.templates_root = ["templates", "templates_mobile"]
to configure that.

The old config
config.handlebars.templates_root = "templates"
is still supported
