### PR TITLE
Enabled partial templates_root matching (updating #102)

### DIFF
--- a/lib/ember/handlebars/template.rb
+++ b/lib/ember/handlebars/template.rb
@@ -77,11 +77,11 @@ module Ember
 
         if root.kind_of? Array
           root.each do |root|
-            path.gsub!(/^#{Regexp.quote(root)}\//, '')
+            path.sub!(/#{Regexp.quote(root)}\//, '')
           end
         else
           unless root.empty?
-            path.gsub!(/^#{Regexp.quote(root)}\/?/, '')
+            path.sub!(/#{Regexp.quote(root)}\/?/, '')
           end
         end
 

--- a/test/hjstemplate_test.rb
+++ b/test/hjstemplate_test.rb
@@ -66,6 +66,17 @@ class HjsTemplateTest < ActionController::IntegrationTest
     end
   end
 
+  test "should allow partial templates_root matching" do
+    with_template_root("templates") do
+      t = Ember::Handlebars::Template.new {}
+      path = t.send(:template_path, 'app/templates/example')
+      assert_equal 'app/example', path
+
+      path = t.send(:template_path, 'admin/templates/admin_example')
+      assert_equal 'admin/admin_example', path
+    end
+  end
+
   test "asset pipeline should serve template" do
     get "/assets/templates/test.js"
     assert_response :success


### PR DESCRIPTION
This is the same functionality as #102, just updated to work with some more recent changes to `handlebars/template`.
