### PR TITLE
Add note on sprockets cache to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Default behavior for ember-rails is to precompile handlebars templates only in p
 If you don't want this behavior you can turn it off in your application configuration block :
 
     config.handlebars.precompile = false
+    
+(Remember to clear the local sprockets cache if you change the value of precompile, by default at `tmp/cache/assets`)
 
 Bundle all templates together thanks to Sprockets,
 e.g create `app/assets/javascripts/templates/all.js` with:


### PR DESCRIPTION
Add minor notice on how the local cache must be cleared when the value of precompile is changed.

The programatical solution to this is to condition the cache on the value of this setting. Right now it's only a file fingerprint, but if this can be changed to a union of the fingerprint and the configuration that would fix it.
