### PR TITLE
Updated README.md to match ember:bootstrap output

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,12 @@ Additionally, it will add the following lines to `app/assets/javascripts/applica
 By default, it uses the Rails Application's name and creates an `rails_app_name.js` 
 file to setup application namespace and initial requires:
 
+    //= require handlebars
     //= require ember
-    //= require ember/app
+    //= require ember-data
+    //= require_self
+    //= require rails_app_name
+    RailsAppName = Ember.Application.create();
 
 *Example:*
 


### PR DESCRIPTION
I'm new to this gem (and to Ember) and just noticed an inconsistency between the readme and the result of the `ember:bootstrap` output. Specifically, the includes that the generator adds to `application.js` didn't match what I was seeing, so I updated the doc. I hope this looks right, but understand you might already be working toward a rewrite that encompasses this change.

Thanks for the great project!

Cheers,
Andy
