### PR TITLE
Update vendored development ember.js to 1.0.0-rc.1

### DIFF
--- a/vendor/ember/development/ember.js
+++ b/vendor/ember/development/ember.js
@@ -1,5 +1,5 @@
-// Version: v1.0.0-pre.4-206-g4f2036f
-// Last commit: 4f2036f (2013-02-12 17:02:00 +0100)
+// Version: v1.0.0-rc.1
+// Last commit: 8b061b4 (2013-02-15 12:10:22 -0800)
 
 
 (function() {
@@ -21076,8 +21076,7 @@ Ember.Select = Ember.View.extend(
 
   tagName: 'select',
   classNames: ['ember-select'],
-  defaultTemplate: Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [2,'>= 1.0.0-rc.3'];
+  defaultTemplate: Ember.Handlebars.template(function anonymous(Handlebars, depth0, helpers, partials, data) { this.compilerInfo = [2,'>= 1.0.0-rc.3'];
 helpers = helpers || Ember.Handlebars.helpers; data = data || {};
   var buffer = '', stack1, hashTypes, escapeExpression=this.escapeExpression, self=this;
 


### PR DESCRIPTION
Ember was updated to rc1 in https://github.com/emberjs/ember-rails/commit/342ad95e3ddb5dd43ae37200637704175cfb46a0, but the development version of ember.js still shows it as pre4 (see [here](https://github.com/emberjs/ember-rails/blob/342ad95e3ddb5dd43ae37200637704175cfb46a0/vendor/ember/development/ember.js#L1)). This updates `vendor/development/ember.js` to 1.0.0-rc.1.
