### PR TITLE
Support belongs to

### DIFF
--- a/lib/generators/templates/model.js
+++ b/lib/generators/templates/model.js
@@ -1,10 +1,10 @@
 <%= application_name.camelize %>.<%= class_name %> = DS.Model.extend({
-<% attributes.each_index do |idx| -%>
-  <%= attributes[idx][:name].camelize(:lower) %>: <%=
-  if %w(references belongs_to).member?(attributes[idx][:type])
-    "DS.belongsTo('%s.%s')" % [application_name.camelize, attributes[idx][:name].camelize]
+<% attributes.each_with_index do |attribute, idx| -%>
+  <%= attribute[:name].camelize(:lower) %>: <%=
+  if %w(references belongs_to).member?(attribute[:type])
+    "DS.belongsTo('%s.%s')" % [application_name.camelize, attribute[:name].camelize]
   else
-    "DS.attr('%s')" % attributes[idx][:type]
+    "DS.attr('%s')" % attribute[:type]
   end
   %><% if (idx < attributes.length-1) %>,<% end %>
 <% end -%>


### PR DESCRIPTION
(I sent new PR because I couldn't stack up to #96. I'm sorry.)

I want to use 'references' in scaffold generator.

When the following command run, I hope that the model was generated validly.
`$ rails generate scaffold comment post:reference body:text`

expected:

``` js
App.Comment = DS.Model.extend({
  post: DS.belongsTo('App.Post'),
  body: DS.attr('string')
});
```

But actual:

``` js
App.Comment = DS.Model.extend({
  post: DS.attr('references'),
  body: DS.attr('string')
});
```
