### PR TITLE
Amended README with note to clear local sprockets cache after modifying ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ By default, `templates_root` is `'templates'`.
 If you store templates in a file like `app/assets/javascripts/ember_templates/admin_panel.handlebars` after setting the above config,
 it will be made available to Ember as the `admin_panel` template.
 
+_(Note: you must clear the local sprockets cache after modifying `templates_root`, stored by default in `tmp/cache/assets`)_
+
 Default behavior for ember-rails is to precompile handlebars templates.
 If you don't want this behavior you can turn it off in your application configuration (or per environment in: `config/environments/development.rb`) block:
 


### PR DESCRIPTION
Changes to `templates_root` don't take effect until `/tmp/cache/assets` is cleared. This came up on [a stack overflow question](http://stackoverflow.com/questions/14948410/how-can-i-specify-an-alternative-directory-for-my-handlebarsjs-templates-with-th) and can be quite mystifying. I think it merits mention in the README.
