### PR TITLE
Ensure rake clean is called before rake dist for install head generator.

### DIFF
--- a/lib/generators/ember/install_generator.rb
+++ b/lib/generators/ember/install_generator.rb
@@ -29,11 +29,10 @@ module Ember
           end
 
           Dir.chdir git_root do
-            say_status("building", "bundle && bundle exec rake clean && bundle exec rake dist", :green)
+            say_status("building", "bundle && bundle exec rake clean dist", :green)
             Bundler.with_clean_env do
               cmd "bundle --gemfile #{gem_file}"
-              cmd %{BUNDLE_GEMFILE="#{gem_file}" bundle exec rake clean}
-              cmd %{BUNDLE_GEMFILE="#{gem_file}" bundle exec rake dist}
+              cmd %{BUNDLE_GEMFILE="#{gem_file}" bundle exec rake clean dist}
             end
           end
 
@@ -66,11 +65,10 @@ module Ember
           end
 
           Dir.chdir git_root do
-            say_status("building", "bundle && bundle exec rake clean && bundle exec rake dist", :green)
+            say_status("building", "bundle && bundle exec rake clean dist", :green)
             Bundler.with_clean_env do
               cmd "bundle --gemfile #{gem_file}"
-              cmd %{BUNDLE_GEMFILE="#{gem_file}" bundle exec rake clean}
-              cmd %{BUNDLE_GEMFILE="#{gem_file}" bundle exec rake dist}
+              cmd %{BUNDLE_GEMFILE="#{gem_file}" bundle exec rake clean dist}
             end
           end
 


### PR DESCRIPTION
If a user has previously used `ember:install --head` and they have not removed `~/.ember` or `~/.ember-data` there is the potential that the next time they run the command, the resulting build will be corrupt in some way. This stops that from happening as it ensures the proper build workflow is followed.
