### PR TITLE
Fix to use bootstrap generator with a custom path with --ember_path option.

### DIFF
--- a/lib/generators/ember/bootstrap_generator.rb
+++ b/lib/generators/ember/bootstrap_generator.rb
@@ -44,7 +44,7 @@ module Ember
 
       private
       def inject_into_application_file(safe_extension)
-        application_file = "app/assets/javascripts/application.#{safe_extension}"
+        application_file = "#{ember_path}/application.#{safe_extension}"
         inject_into_file( application_file, :before => /^.*require_tree.*$/) do
           context = instance_eval('binding')
           source  = File.expand_path(find_in_source_paths("application.#{safe_extension}"))

--- a/test/dummy/app/assets/javascripts/custom/application.js
+++ b/test/dummy/app/assets/javascripts/custom/application.js
@@ -1,0 +1,10 @@
+// This is a manifest file that'll be compiled into including all the files listed below.
+// Add new JavaScript/Coffee code in separate files in this directory and they'll automatically
+// be included in the compiled file accessible from http://example.com/assets/application.js
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// the compiled file.
+//
+//= require handlebars
+//= require ember
+//= require ember-data
+//= require_tree .


### PR DESCRIPTION
I ran into the problem in issue #74, running the bootstrap generator in a rails 3.x engine. The problem is that the generator requires the file app/assets/javascripts/application.js to exist, because the generator add to it. Rails 3.x engines use namespacing, so in an engine named custom, the application.js file will be found at app/assets/javascripts/custom/application.js. I tried to use the --ember_path option, however it didn't work because it was still looking for app/assets/javascripts/application.js. This simple fix uses the already existing ember_path variable to get to the application.js file. I also added test/dummy/app/assets/javascripts/custom/application.js, which was necessary keep the tests passing with this fix.
