### PR TITLE
Added 'handelbars-source' to gemspec as development dependency

### DIFF
--- a/ember-rails.gemspec
+++ b/ember-rails.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |s|
   s.add_dependency "barber", [">= 0.4.1"]
   s.add_dependency "ember-source"
   s.add_dependency "ember-data-source"
+  s.add_dependency "handlebars-source"
 
   s.add_development_dependency "bundler", [">= 1.2.2"]
   s.add_development_dependency "appraisal"
   s.add_development_dependency "tzinfo"
-  s.add_development_dependency "handlebars-source"
 
   s.files = %w(README.md LICENSE) + Dir["lib/**/*", "vendor/**/*"]
 


### PR DESCRIPTION
Add 'handlebars-source' as a development dependency to do a 'bundle install' on the latest version of HEAD.
