### PR TITLE
Update ember-source dependency and appraisals

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,34 +1,34 @@
-appraise "rails31_ember_pre4" do
+appraise "rails31_ember_rc2" do
   gem 'rails', '~> 3.1'
-  gem 'ember-source', '1.0.0.pre4.2'
+  gem 'ember-source', "1.0.0.rc2.2"
 end
 
-appraise "rails31_ember_rc1" do
+appraise "rails31_ember_rc3" do
   gem 'rails', '~> 3.1'
-  gem 'ember-source', "1.0.0.rc1.2"
+  gem 'ember-source', "1.0.0.rc3.1"
 end
 
-appraise "rails32_ember_pre4" do
+appraise "rails32_ember_rc2" do
   gem 'rails', '~> 3.2'
-  gem 'ember-source', '1.0.0.pre4.2'
+  gem 'ember-source', "1.0.0.rc2.2"
 end
 
-appraise "rails32_ember_rc1" do
+appraise "rails32_ember_rc3" do
   gem 'rails', '~> 3.2'
-  gem 'ember-source', "1.0.0.rc1.2"
+  gem 'ember-source', "1.0.0.rc3.1"
 end
 
 unless RUBY_VERSION == "1.8.7"
-  appraise "rails4_ember_pre4" do
+  appraise "rails4_ember_rc2" do
     gem 'rails', :git => 'https://github.com/rails/rails.git'
     gem 'activerecord-deprecated_finders', :git => 'https://github.com/rails/activerecord-deprecated_finders.git'
-    gem 'ember-source', '1.0.0.pre4.2'
+    gem 'ember-source', "1.0.0.rc2.2"
   end
 
-  appraise "rails4_ember_rc1" do
+  appraise "rails4_ember_rc3" do
     gem 'rails', :git => 'https://github.com/rails/rails.git'
     gem 'activerecord-deprecated_finders', :git => 'https://github.com/rails/activerecord-deprecated_finders.git'
-    gem 'ember-source', "1.0.0.rc1.2"
+    gem 'ember-source', "1.0.0.rc3.1"
   end
 end
 

--- a/ember-rails.gemspec
+++ b/ember-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "railties", [">= 3.1"]
   s.add_dependency "active_model_serializers"
   s.add_dependency "barber", [">= 0.4.1"]
-  s.add_dependency "ember-source"
+  s.add_dependency "ember-source", ["<= 1.0.0.rc3.1", ">= 1.0.0.rc2.2"]
   s.add_dependency "ember-data-source"
 
   s.add_development_dependency "bundler", [">= 1.2.2"]


### PR DESCRIPTION
Test against latest Ember RC2 and RC3 gems, and Rails 3.1, 3.2 and 4, and specify gem dependencies accordingly.

[Fixes #165 #168] and replaces #178
