### PR TITLE
Remove `Ember::VERSION`

### DIFF
--- a/lib/ember/version.rb
+++ b/lib/ember/version.rb
@@ -1,3 +1,0 @@
-module Ember
-  VERSION = "1.0.0-rc.1"
-end

--- a/lib/ember_rails.rb
+++ b/lib/ember_rails.rb
@@ -1,6 +1,5 @@
 require 'rails'
 require 'ember/rails/version'
-require 'ember/version'
 require 'ember/rails/engine'
 require 'ember/source'
 require 'ember/data/source'

--- a/lib/generators/ember/bootstrap_generator.rb
+++ b/lib/generators/ember/bootstrap_generator.rb
@@ -1,4 +1,3 @@
-require 'ember/version'
 require 'generators/ember/generator_helpers'
 
 module Ember

--- a/lib/generators/ember/controller_generator.rb
+++ b/lib/generators/ember/controller_generator.rb
@@ -1,4 +1,3 @@
-require 'ember/version'
 require 'generators/ember/generator_helpers'
 
 module Ember

--- a/lib/generators/ember/install_generator.rb
+++ b/lib/generators/ember/install_generator.rb
@@ -1,4 +1,3 @@
-require 'ember/version'
 require 'generators/ember/generator_helpers'
 
 module Ember

--- a/lib/generators/ember/model_generator.rb
+++ b/lib/generators/ember/model_generator.rb
@@ -1,4 +1,3 @@
-require 'ember/version'
 require 'generators/ember/generator_helpers'
 
 module Ember

--- a/lib/generators/ember/resource_generator.rb
+++ b/lib/generators/ember/resource_generator.rb
@@ -1,4 +1,3 @@
-require 'ember/version'
 require 'generators/ember/generator_helpers'
 
 module Ember
@@ -23,7 +22,6 @@ module Ember
         invoke('ember:view', [ name ], options)
         invoke('ember:template', [ name ], options) 
       end
-
 
     end
   end

--- a/lib/generators/ember/route_generator.rb
+++ b/lib/generators/ember/route_generator.rb
@@ -1,4 +1,3 @@
-require 'ember/version'
 require 'generators/ember/generator_helpers'
 
 module Ember

--- a/lib/generators/ember/template_generator.rb
+++ b/lib/generators/ember/template_generator.rb
@@ -1,4 +1,3 @@
-require 'ember/version'
 require 'generators/ember/generator_helpers'
 
 module Ember

--- a/lib/generators/ember/view_generator.rb
+++ b/lib/generators/ember/view_generator.rb
@@ -1,4 +1,3 @@
-require 'ember/version'
 require 'generators/ember/generator_helpers'
 
 module Ember


### PR DESCRIPTION
I think it should be defined in `ember-source`.
This PR is related with emberjs/ember.js#2615.
