### PR TITLE
Require correct handlebars version

### DIFF
--- a/ember-rails.gemspec
+++ b/ember-rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "tzinfo"
 
   s.add_development_dependency "ember-source", '1.0.0.rc3.4'
-  s.add_development_dependency "handlebars-source", '1.0.0.rc4'
+  s.add_development_dependency "handlebars-source", '1.0.11'
 
   s.files = %w(README.md LICENSE) + Dir["lib/**/*", "vendor/**/*"]
 


### PR DESCRIPTION
It seems like it was recently bumped to `1.0.11`.

Related to: https://github.com/emberjs/ember.js/pull/2701
