### PR TITLE
Remove unnecessary `Ember::Handlebars::VERSION`

### DIFF
--- a/lib/ember/handlebars/version.rb
+++ b/lib/ember/handlebars/version.rb
@@ -1,5 +1,0 @@
-module Ember
-  module Handlebars
-    VERSION = "1.0.rc.3"
-  end
-end


### PR DESCRIPTION
It couldn't specify from ember-rails because it depends on handlebars-source.
