### PR TITLE
Better documentation for engine choice

### DIFF
--- a/lib/generators/ember/bootstrap_generator.rb
+++ b/lib/generators/ember/bootstrap_generator.rb
@@ -11,7 +11,7 @@ module Ember
 
       class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "Custom ember app path"
       class_option :skip_git, :type => :boolean, :aliases => "-g", :default => false, :desc => "Skip Git keeps"
-      class_option :javascript_engine, :desc => "Engine for JavaScripts"
+      class_option :javascript_engine, :desc => "Engine for JavaScripts (js for JavaScript, coffee for CoffeeScript, etc)"
       class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
 
       def inject_ember


### PR DESCRIPTION
I automatically assumed `--javascript-engine=javascript` would work, but it didn't. Apparently it should be `js` instead. In the end the generator should probably support either, but this should suffice for now.
