### PR TITLE
Update DS.Store revision number

### DIFF
--- a/lib/generators/templates/store.js
+++ b/lib/generators/templates/store.js
@@ -1,6 +1,6 @@
 // http://emberjs.com/guides/models/defining-a-store/
 
 <%= application_name.camelize %>.Store = DS.Store.extend({
-  revision: 11,
+  revision: 13,
   adapter: DS.RESTAdapter.create()
 });

--- a/lib/generators/templates/store.js.coffee
+++ b/lib/generators/templates/store.js.coffee
@@ -1,6 +1,5 @@
 # http://emberjs.com/guides/models/defining-a-store/
 
 <%= application_name.camelize %>.Store = DS.Store.extend
-  revision: 11
+  revision: 13
   adapter: DS.RESTAdapter.create()
-


### PR DESCRIPTION
Update revision number from 11 to 13. I opted to state the revision number, just to serve as a remainder to folks who decide not to use the latest version of Ember Data.
