### PR TITLE
Readme refers to new 'ember-source', '1.0.0.rc6.2'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 gemspec
 
-#gem 'handlebars-source', '1.0.0.rc4'
-#gem 'ember-source', '1.0.0.rc3.4'
+#gem 'handlebars-source', '~> 1.0.12'
+#gem 'ember-source', '1.0.0.rc6.2'

--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ You can see an example of how to use the gem [here](https://github.com/keithpitt
 
 ## Getting started
 1. Add the gem to your application Gemfile:
+
 ```ruby
 gem 'ember-rails'
-gem 'ember-source', '1.0.0.rc6' # or the version you need
-gem 'handlebars-source', '1.0.0.rc4' # or the version you need
+gem 'ember-source', '1.0.0.rc6.2' # or the version you need
+
+# optional since Handlebars 1.0.0 was released
+#gem 'handlebars-source', '~> 1.0.12' # or the version you need
 ```
 
 2. Run `bundle install`


### PR DESCRIPTION
I pushed [http://rubygems.org/gems/ember-source/versions/1.0.0.rc6.2](ember-source rc6.2) to Rubygems, removing its dependency on pre-release Handlebars, which means we are free from a chunk of pre-release hell. Specifically, if you want to use a non-pre-release Handlebars (i.e. >= 1.0.0), you don't have to specify `handlebars-source` in your Gemfile anymore. Yay.
