### PR TITLE
Updated readme with inclusion of rake tmp:clear after install with --head.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can see an example of how to use the gem [here](https://github.com/keithpitt
 
 ```ruby
 gem 'ember-rails'
-gem 'ember-source', '1.0.0.rc6.3' # or the version you need
+gem 'ember-source', '1.0.0.rc6.4' # or the version you need
 
 # optional since Handlebars 1.0.0 was released
 #gem 'handlebars-source', '~> 1.0.12' # or the version you need
@@ -38,6 +38,12 @@ To install the latest builds of ember and ember-data:
 ```shell
 rails generate ember:install --head
 ```
+
+You'll probably need to clear out your cache after doing this with
+
+```shell
+rake tmp:clear
+```:
 
 ## For CoffeeScript support
 1. Add coffee-rails to the Gemfile


### PR DESCRIPTION
As requested by @stefanpenner I've updated the README.md to reflect what was discussed in this issue:

https://github.com/emberjs/ember-rails/issues/228

Effectively 2 small changes:
- version bump of ember-source
- rake tmp:clear requirement after install with --head
