### PR TITLE
Rails engine integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ pkg/*
 *.log
 test/dummy/tmp
 .DS_Store
+*.swp
+*.swo

--- a/lib/generators/ember/generator_helpers.rb
+++ b/lib/generators/ember/generator_helpers.rb
@@ -3,19 +3,32 @@ module Ember
     module GeneratorHelpers
 
       def ember_path
-        options[:ember_path] || "app/assets/javascripts"
+        if rails_engine?
+          options[:ember_path] || "app/assets/javascripts/#{engine_name}"
+        else
+          options[:ember_path] || "app/assets/javascripts"
+        end
+      end
+
+      def rails_engine?
+        defined?(ENGINE_PATH)
+      end
+
+      def engine_name
+        ENGINE_PATH.split('/')[-2]
       end
 
       def application_name
         if options[:app_name]
           options[:app_name]
+        elsif rails_engine?
+          engine_name
         elsif defined?(::Rails) && ::Rails.application
           ::Rails.application.class.name.split('::').first
         else
           "App"
         end
       end
-
 
       def class_name
         (class_path + [file_name]).map!{ |m| m.camelize }.join()

--- a/test/dummy/app/assets/javascripts/dummy/application.js
+++ b/test/dummy/app/assets/javascripts/dummy/application.js
@@ -1,0 +1,10 @@
+// This is a manifest file that'll be compiled into including all the files listed below.
+// Add new JavaScript/Coffee code in separate files in this directory and they'll automatically
+// be included in the compiled file accessible from http://example.com/assets/application.js
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// the compiled file.
+//
+//= require handlebars
+//= require ember
+//= require ember-data
+//= require_tree .

--- a/test/dummy/config/engine.rb
+++ b/test/dummy/config/engine.rb
@@ -1,0 +1,2 @@
+ENGINE_ROOT = File.expand_path('../../', __FILE__) unless defined?(ENGINE_ROOT)
+ENGINE_PATH = "#{ENGINE_ROOT}/lib/dummy/engine" unless defined?(ENGINE_PATH)

--- a/test/generators/bootstrap_generator_engine_test.rb
+++ b/test/generators/bootstrap_generator_engine_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+require 'generators/ember/bootstrap_generator'
+require File.expand_path('../../dummy/config/engine', __FILE__)
+
+class BootstrapGeneratorEngineTest < Rails::Generators::TestCase
+  tests Ember::Generators::BootstrapGenerator
+  destination File.join(ENGINE_ROOT, "tmp", "generator_engine_test_output")
+
+  setup :prepare_destination
+  teardown :cleanup
+
+  def copy_directory(dir)
+    source = File.join(ENGINE_ROOT, dir)
+    dest = File.join(ENGINE_ROOT, "tmp", "generator_engine_test_output", File.dirname(dir))
+
+    FileUtils.mkdir_p dest
+    FileUtils.cp_r source, dest
+  end
+
+  def prepare_destination
+    super
+
+    load File.expand_path('../../dummy/config/engine.rb', __FILE__)
+    copy_directory "app/assets/javascripts"
+    copy_directory "config"
+  end
+
+  def cleanup
+    Object.send(:remove_const, :ENGINE_ROOT)
+    Object.send(:remove_const, :ENGINE_PATH)
+  end
+
+  test "Assert folder layout and .gitkeep files are properly created in a rails engine" do
+    run_generator
+    assert_new_dirs(:skip_git => false)
+  end
+
+  test "Assert folder layout is properly created without .gitkeep files in a rails engine" do
+    run_generator %w(-g)
+    assert_new_dirs(:skip_git => true)
+  end
+
+  %w(js coffee).each do |engine|
+
+    test "create bootstrap in a rails engine with #{engine}" do
+      run_generator ["--javascript-engine=#{engine}"]
+      assert_file "#{ember_path}/store.js.#{engine}".sub('.js.js','.js')
+      assert_file "#{ember_path}/router.js.#{engine}".sub('.js.js','.js')
+      assert_file "#{ember_path}/#{engine_name}.js.#{engine}".sub('.js.js','.js')
+    end
+
+    test "create bootstrap in a rails engine with #{engine} engine and custom path" do
+      custom_path = ember_path("custom")
+      run_generator ["--javascript-engine=#{engine}", "-d", custom_path]
+      assert_file "#{custom_path}/store.js.#{engine}".sub('.js.js','.js')
+      assert_file "#{custom_path}/router.js.#{engine}".sub('.js.js','.js')
+      assert_file "#{custom_path}/#{engine_name}.js.#{engine}".sub('.js.js','.js')
+    end
+
+    test "create bootstrap in a rails engine with #{engine} and custom app name" do
+      run_generator ["--javascript-engine=#{engine}", "-n", "MyEngine"]
+      assert_file "#{ember_path}/store.js.#{engine}".sub('.js.js','.js'), /MyEngine\.Store/
+      assert_file "#{ember_path}/router.js.#{engine}".sub('.js.js','.js'), /MyEngine\.Router\.map/
+      assert_file "#{ember_path}/my_engine.js.#{engine}".sub('.js.js','.js')
+    end
+  end
+
+  private
+
+  def ember_path(custom_path = nil)
+    "app/assets/javascripts/#{custom_path || engine_name}"
+  end
+
+  def assert_new_dirs(options = {})
+    path = options[:in_path] || ember_path
+
+    %W{models controllers views helpers templates routes}.each do |dir|
+      assert_directory "#{path}/#{dir}"
+      assert_file "#{path}/#{dir}/.gitkeep" unless options[:skip_git]
+    end
+  end
+
+  def engine_name
+    "dummy"
+  end
+
+end


### PR DESCRIPTION
Integrate rails engine support into the bootstrap generator. If the generator is run from a rails engine directory it will detect that it is from an engine and extract the name and determine the proper javascript dir to place the generated files into. This is necessary for rails engines because an engine's javascript dir has an extra folder level for example `app/assets/javascripts/my_engine/`. Previously the generator would fail because it would not be able to find `app/assets/javascripts/application.js`. It uses the constants ENGINE_PATH and ENGINE_ROOT to detect a rails engine and get it's name.
