### PR TITLE
prepend source URI and fetched date when using install generator.

### DIFF
--- a/lib/generators/ember/install_generator.rb
+++ b/lib/generators/ember/install_generator.rb
@@ -34,6 +34,8 @@ module Ember
         FileUtils.mkdir_p File.dirname(to)
 
         open(to, 'w+') do |output|
+          output.puts "// Fetched from: " + uri.to_s
+          output.puts "// Fetched on: " + Time.now.utc.iso8601.to_s
           output.puts Net::HTTP.get(uri).force_encoding("UTF-8")
         end
       end


### PR DESCRIPTION
Puts a the Source URI and the fetch date at the top of the source file.

Provides a little information about where the Ember Source came from.

Will try adding version based fetching in another PR after doing some more research.
