### PR TITLE
remove ember data revisions in generator templates

### DIFF
--- a/lib/generators/templates/store.js
+++ b/lib/generators/templates/store.js
@@ -1,6 +1,5 @@
 // http://emberjs.com/guides/models/defining-a-store/
 
 <%= application_name.camelize %>.Store = DS.Store.extend({
-  revision: 13,
   adapter: DS.RESTAdapter.create()
 });

--- a/lib/generators/templates/store.js.coffee
+++ b/lib/generators/templates/store.js.coffee
@@ -1,5 +1,4 @@
 # http://emberjs.com/guides/models/defining-a-store/
 
 <%= application_name.camelize %>.Store = DS.Store.extend
-  revision: 13
   adapter: DS.RESTAdapter.create()


### PR DESCRIPTION
Revisions are no longer needed in stable version.

This could cause weird problems when upgrading to ember 1.0 using ember-rails gem.
