### PR TITLE
Switching to DS.ActiveModelAdapter so underscore to camel works by default.

### DIFF
--- a/lib/generators/templates/store.js
+++ b/lib/generators/templates/store.js
@@ -1,8 +1,7 @@
 // http://emberjs.com/guides/models/using-the-store/
-//
-// Use DS.ActiveModelAdapter here rather than the DS.RESTAdapter because
-// it is built to work nicely with the ActiveModel::Serializers gem.
 
 <%= application_name.camelize %>.Store = DS.Store.extend({
-  adapter: DS.ActiveModelAdapter.extend({})
+  // Override the default adapter with the `DS.ActiveModelAdapter` which
+  // is built to work nicely with the ActiveModel::Serializers gem.
+  adapter: '_ams'
 });

--- a/lib/generators/templates/store.js.coffee
+++ b/lib/generators/templates/store.js.coffee
@@ -1,7 +1,6 @@
 # http://emberjs.com/guides/models/using-the-store/
-#
-# Use DS.ActiveModelAdapter here rather than the DS.RESTAdapter because
-# it is built to work nicely with the ActiveModel::Serializers gem.
 
 <%= application_name.camelize %>.Store = DS.Store.extend
-  adapter: DS.ActiveModelAdapter.extend({})
+  # Override the default adapter with the `DS.ActiveModelAdapter` which
+  # is built to work nicely with the ActiveModel::Serializers gem.
+  adapter: '_ams'


### PR DESCRIPTION
From viewing https://github.com/emberjs/data/issues/1180 and https://github.com/emberjs/data/pull/1206, it appears that the direction moving forward should be to use the DS.ActiveModelAdapter in this project instead of DS.RESTAdapter.  If this is not the case it would be nice to get `ActiveModel::Serializers` setup to use camelCasing by default in this project instead.  Currently, without taking either action, things just don't work correctly.  This should make it work by default.
