### PR TITLE
Added options to ember:install beta or canary version of ember & ember-data

### DIFF
--- a/lib/generators/ember/install_generator.rb
+++ b/lib/generators/ember/install_generator.rb
@@ -8,19 +8,28 @@ module Ember
     class InstallGenerator < ::Rails::Generators::Base
       desc "Install Ember.js into your vendor folder"
       class_option :head, :type => :boolean, :default => false, :desc => "Download latest Ember.js from GitHub and fetch it into your project"
+      class_option :release, :type => :string, :required => false, :desc => "Release type of ember. Choose between 'head', 'beta' or 'canary'"
 
-      def fetch_ember
+
+      def release_type
+        if options.head? && options.release
+          say_status('conflicting options', '--head prevailed over --release option' , :red)
+        end
         if options.head?
-          fetch 'http://builds.emberjs.com/ember-latest.js', 'vendor/assets/ember/development/ember.js'
-          fetch 'http://builds.emberjs.com/ember-latest.min.js', 'vendor/assets/ember/production/ember.js'
+          ''
+        else
+          options['release'] + '/'
         end
       end
 
+      def fetch_ember
+        fetch "http://builds.emberjs.com/#{release_type}ember-latest.js", 'vendor/assets/ember/development/ember.js'
+        fetch "http://builds.emberjs.com/#{release_type}ember-latest.min.js", 'vendor/assets/ember/production/ember.js'
+      end
+
       def fetch_ember_data
-        if options.head?
-          fetch 'http://builds.emberjs.com/ember-data-latest.js', 'vendor/assets/ember/development/ember-data.js'
-          fetch 'http://builds.emberjs.com/ember-data-latest.min.js', 'vendor/assets/ember/production/ember-data.js'
-        end
+        fetch "http://builds.emberjs.com/#{release_type}ember-data-latest.js", 'vendor/assets/ember/development/ember-data.js'
+        fetch "http://builds.emberjs.com/#{release_type}ember-data-latest.min.js", 'vendor/assets/ember/production/ember-data.js'
       end
 
     private


### PR DESCRIPTION
I would like an easy way to be able to use a canary of beta release of ember in my rails project. Right now ember-rails only supports `--head` options to `rails generate ember:install`. This pull request adds the options to specify a release

``` sh
rails generate ember:install --release=canary
```

installs the current canary release

``` sh
rails generate ember:install --release=beta
```

installs the current beta release.

For backwards compatibility, the --head option is preserved.

Current code could use some love. I'm not really into Thor.  and the check's for the right options is probably not as it should be.
