### PR TITLE
Add jquery-rails as a dependency. Fixes #263

### DIFF
--- a/ember-rails.gemspec
+++ b/ember-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ember-source"
   s.add_dependency "handlebars-source"
   s.add_dependency "ember-data-source"
-
+  s.add_dependency "jquery-rails", ">= 1.0.17"
 
   s.add_development_dependency "bundler", [">= 1.2.2"]
   s.add_development_dependency "appraisal"


### PR DESCRIPTION
Requires jQuery version >= 1.7.0
