### PR TITLE
Add AMD output option for handlebars templates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ Ember-rails include some flags options for bootstrap generator:
 --app-name or -n # custom ember app name
 ```
 
+## Configuration Options
+
+The following options are availabe for configuration in your application or environment level
+config files (`config/application.rb`, `config/environments/development.rb`, etc.):
+
+* `config.handlebars.precompile` - Used to enable or disable precompilation. Default value: `true`.
+* `config.handlebars.templates_root` - Set the root path (under `app/assets/javascripts`) for templates
+  to be looked up in. Default value: `"templates"`.
+* `config.handlebars.templates_path_separator` - The path separator to use for templates. Default value: `'/'`.
+* `config.handlebars.output_type` - Configures the style of output (options are `:amd` and `:global`).
+  Default value: `:global`.
+
 ## Architecture
 
 Ember does not require an organized file structure. However, ember-rails allows you

--- a/lib/ember/handlebars/template.rb
+++ b/lib/ember/handlebars/template.rb
@@ -12,7 +12,6 @@ module Ember
       def prepare; end
 
       def evaluate(scope, locals, &block)
-        target = template_target(scope)
         raw = handlebars?(scope)
 
         if raw
@@ -35,7 +34,15 @@ module Ember
           end
         end
 
-        "#{target} = #{template}\n"
+        if configuration.output_type == :amd
+          target = amd_template_target(scope)
+
+          "define('#{target}', [], function(){ return #{template} });"
+        else
+          target = global_template_target(scope)
+
+          "#{target} = #{template}\n"
+        end
       end
 
       private
@@ -44,7 +51,11 @@ module Ember
         scope.pathname.to_s =~ /\.raw\.(handlebars|hjs|hbs)/
       end
 
-      def template_target(scope)
+      def amd_template_target(scope)
+        "#{configuration.amd_namespace}/#{scope.logical_path.split(".").first}"
+      end
+
+      def global_template_target(scope)
         "Ember.TEMPLATES[#{template_path(scope.logical_path).inspect}]"
       end
 

--- a/lib/ember/rails/engine.rb
+++ b/lib/ember/rails/engine.rb
@@ -9,6 +9,7 @@ module Ember
       config.handlebars.precompile = true
       config.handlebars.templates_root = "templates"
       config.handlebars.templates_path_separator = '/'
+      config.handlebars.output_type = :global
 
       config.before_initialize do |app|
         Sprockets::Engines #force autoloading

--- a/test/hjstemplate_test.rb
+++ b/test/hjstemplate_test.rb
@@ -38,6 +38,16 @@ class HjsTemplateTest < IntegrationTest
     handlebars.templates_path_separator = old_sep if sep
   end
 
+  def with_amd_output
+    old, handlebars.output_type = handlebars.output_type, :amd
+    old_namespace, handlebars.amd_namespace = handlebars.amd_namespace, 'appkit'
+
+    yield
+  ensure
+    handlebars.output_type = old
+    handlebars.amd_namespace = old_namespace
+  end
+
   test "should replace separators with templates_path_separator" do
     with_template_root("", "-") do
       t = Ember::Handlebars::Template.new {}
@@ -83,6 +93,16 @@ class HjsTemplateTest < IntegrationTest
 
       path = t.send(:template_path, 'admin/templates/admin_example')
       assert_equal 'admin/admin_example', path
+    end
+  end
+
+  test "template with AMD output" do
+    with_amd_output do
+      template_path = ::Rails.root.join('app/assets/javascripts/templates/test.js.hjs')
+      template = Ember::Handlebars::Template.new template_path.to_s
+      asset = app.assets.attributes_for(template_path)
+
+      assert_match /define\('appkit\/templates\/test', \[\], function\(\)\{ return Ember\.Handlebars\.template\(function .*"test"/m, template.render(asset)
     end
   end
 


### PR DESCRIPTION
Adds configuration options to output compiled templates to AMD format instead
of storing them directly on `Ember.TEMPLATES`.
