### PR TITLE
Add config.ember.app_name option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Ember-rails include some flags options for bootstrap generator:
 The following options are availabe for configuration in your application or environment level
 config files (`config/application.rb`, `config/environments/development.rb`, etc.):
 
+* `config.ember.variant` (**REQUIRED**) - Used to determine which Ember variant to use. Valid options: `:development`, `:production`.
+* `config.ember.app_name` - Used to specify a default application name for all generators.
 * `config.handlebars.precompile` - Used to enable or disable precompilation. Default value: `true`.
 * `config.handlebars.templates_root` - Set the root path (under `app/assets/javascripts`) for templates
   to be looked up in. Default value: `"templates"`.

--- a/lib/ember_rails.rb
+++ b/lib/ember_rails.rb
@@ -25,7 +25,7 @@ module Ember
           # test environments should default to development
           variant ||= :development
           # Copy over the desired ember, ember-data, and handlebars bundled in
-          # ember-source, ember-data-source, and handlebars-source to a tmp folder. 
+          # ember-source, ember-data-source, and handlebars-source to a tmp folder.
           tmp_path = app.root.join("tmp/ember-rails")
           ext = variant == :production ? ".prod.js" : ".js"
           FileUtils.mkdir_p(tmp_path)

--- a/lib/generators/ember/generator_helpers.rb
+++ b/lib/generators/ember/generator_helpers.rb
@@ -21,6 +21,8 @@ module Ember
       def application_name
         if options[:app_name]
           options[:app_name]
+        elsif configuration.app_name
+          configuration.app_name
         elsif rails_engine?
           engine_name
         elsif defined?(::Rails) && ::Rails.application
@@ -35,11 +37,15 @@ module Ember
       end
 
       def handlebars_template_path
-        File.join(class_path, file_name).gsub(/^\//, '') 
+        File.join(class_path, file_name).gsub(/^\//, '')
       end
 
       def engine_extension
         @engine_extension ||= "js.#{options[:javascript_engine]}".sub('js.js','js')
+      end
+
+      def configuration
+        ::Rails.configuration.ember
       end
     end
   end

--- a/test/generators/bootstrap_generator_engine_test.rb
+++ b/test/generators/bootstrap_generator_engine_test.rb
@@ -65,6 +65,18 @@ class BootstrapGeneratorEngineTest < Rails::Generators::TestCase
     end
   end
 
+  test "Uses config.ember.app_name as the app name" do
+    begin
+      old, ::Rails.configuration.ember.app_name = ::Rails.configuration.ember.app_name, 'MyApp'
+
+      run_generator %w(ember)
+      assert_file "#{ember_path}/store.js", /MyApp\.Store/
+      assert_file "#{ember_path}/router.js", /MyApp\.Router\.map/
+    ensure
+      ::Rails.configuration.ember.app_name = old
+    end
+  end
+
   private
 
   def ember_path(custom_path = nil)

--- a/test/generators/bootstrap_generator_test.rb
+++ b/test/generators/bootstrap_generator_test.rb
@@ -63,6 +63,18 @@ class BootstrapGeneratorTest < Rails::Generators::TestCase
   end
 
 
+  test "Uses config.ember.app_name as the app name" do
+    begin
+      old, ::Rails.configuration.ember.app_name = ::Rails.configuration.ember.app_name, 'MyApp'
+
+      run_generator %w(ember)
+      assert_file "#{ember_path}/store.js", /MyApp\.Store/
+      assert_file "#{ember_path}/router.js", /MyApp\.Router\.map/
+    ensure
+      ::Rails.configuration.ember.app_name = old
+    end
+  end
+
   private
 
   def assert_invoked_generators_files(options = {})

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -69,6 +69,17 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     assert_file "#{ember_path}/templates/components/post-chart.handlebars"
   end
 
+  test "Uses config.ember.app_name as the app name" do
+    begin
+      old, ::Rails.configuration.ember.app_name = ::Rails.configuration.ember.app_name, 'MyApp'
+
+      run_generator %w(PostChart)
+      assert_file "#{ember_path}/components/post-chart_component.js", /MyApp\.PostChartComponent/
+    ensure
+      ::Rails.configuration.ember.app_name = old
+    end
+  end
+
   private
 
   def ember_path(custom_path = nil)

--- a/test/generators/controller_generator_test.rb
+++ b/test/generators/controller_generator_test.rb
@@ -63,6 +63,17 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
     assert_file "#{ember_path}/controllers/ember_controller.js", /MyApp\.EmberController/
   end
 
+  test "Uses config.ember.app_name as the app name" do
+    begin
+      old, ::Rails.configuration.ember.app_name = ::Rails.configuration.ember.app_name, 'MyApp'
+
+      run_generator %w(ember)
+      assert_file "#{ember_path}/controllers/ember_controller.js", /MyApp\.EmberController/
+    ensure
+      ::Rails.configuration.ember.app_name = old
+    end
+  end
+
   private
 
   def ember_path(custom_path = nil)

--- a/test/generators/model_generator_test.rb
+++ b/test/generators/model_generator_test.rb
@@ -60,6 +60,17 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     assert_file "app/assets/javascripts/models/ember.js", /MyApp\.Ember/
   end
 
+  test "Uses config.ember.app_name as the app name" do
+    begin
+      old, ::Rails.configuration.ember.app_name = ::Rails.configuration.ember.app_name, 'MyApp'
+
+      run_generator %w(ember)
+      assert_file "app/assets/javascripts/models/ember.js", /MyApp\.Ember/
+    ensure
+      ::Rails.configuration.ember.app_name = old
+    end
+  end
+
   private
 
   def ember_path(custom_path = nil)

--- a/test/generators/resource_generator_test.rb
+++ b/test/generators/resource_generator_test.rb
@@ -40,8 +40,19 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
       assert_file "app/assets/javascripts/controllers/post_controller.js.#{engine}".sub('.js.js','.js'), /MyApp\.PostController/
       assert_file "app/assets/javascripts/routes/post_route.js.#{engine}".sub('.js.js','.js'), /MyApp\.PostRoute/
     end
+  end
 
+  test "Uses config.ember.app_name as the app name" do
+    begin
+      old, ::Rails.configuration.ember.app_name = ::Rails.configuration.ember.app_name, 'MyApp'
 
+      run_generator %w(post)
+      assert_file "app/assets/javascripts/views/post_view.js", /MyApp.PostView/
+      assert_file "app/assets/javascripts/controllers/post_controller.js", /MyApp\.PostController/
+      assert_file "app/assets/javascripts/routes/post_route.js", /MyApp\.PostRoute/
+    ensure
+      ::Rails.configuration.ember.app_name = old
+    end
   end
 end
 

--- a/test/generators/route_generator_test.rb
+++ b/test/generators/route_generator_test.rb
@@ -40,6 +40,17 @@ class RouteGeneratorTest < Rails::Generators::TestCase
     assert_file "app/assets/javascripts/routes/ember_route.js", /MyApp\.EmberRoute/
   end
 
+  test "Uses config.ember.app_name as the app name" do
+    begin
+      old, ::Rails.configuration.ember.app_name = ::Rails.configuration.ember.app_name, 'MyApp'
+
+      run_generator %w(ember)
+      assert_file "app/assets/javascripts/routes/ember_route.js", /MyApp\.EmberRoute/
+    ensure
+      ::Rails.configuration.ember.app_name = old
+    end
+  end
+
   private
 
   def ember_path(custom_path = nil)

--- a/test/generators/view_generator_test.rb
+++ b/test/generators/view_generator_test.rb
@@ -60,6 +60,17 @@ class ViewGeneratorTest < Rails::Generators::TestCase
     assert_file "app/assets/javascripts/views/ember_view.js", /AppName\.EmberView/
   end
 
+  test "Uses config.ember.app_name as the app name" do
+    begin
+      old, ::Rails.configuration.ember.app_name = ::Rails.configuration.ember.app_name, 'MyApp'
+
+      run_generator %w(ember)
+      assert_file "app/assets/javascripts/views/ember_view.js", /MyApp\.EmberView/
+    ensure
+      ::Rails.configuration.ember.app_name = old
+    end
+  end
+
   private
 
   def ember_path(custom_path = nil)


### PR DESCRIPTION
Once set (usually in `config/application.rb`), you would no longer need to
specify the `--app-name` argument for each generator that you run.

Closes https://github.com/emberjs/ember-rails/issues/285.

/cc @cavneb
