### PR TITLE
Default `config.ember.variant` based on Rails.env?.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,13 @@ gem 'ember-source', '1.1.2' # or the version you need
 
 2. Run `bundle install`
 
-3. Configure the ember variant in your environment files (i.e. development.rb, production.rb).
-```ruby
-  config.ember.variant = :development # or :production
-```
+3. Next, generate the application structure:
 
-4. Next, generate the application structure:
 ```shell
 rails generate ember:bootstrap
 ```
 
-5. Restart your server (if it's running)
+4. Restart your server (if it's running)
 
 
 Notes:
@@ -79,7 +75,7 @@ Ember-rails include some flags options for bootstrap generator:
 The following options are availabe for configuration in your application or environment level
 config files (`config/application.rb`, `config/environments/development.rb`, etc.):
 
-* `config.ember.variant` (**REQUIRED**) - Used to determine which Ember variant to use. Valid options: `:development`, `:production`.
+* `config.ember.variant` - Used to determine which Ember variant to use. Valid options: `:development`, `:production`.
 * `config.ember.app_name` - Used to specify a default application name for all generators.
 * `config.handlebars.precompile` - Used to enable or disable precompilation. Default value: `true`.
 * `config.handlebars.templates_root` - Set the root path (under `app/assets/javascripts`) for templates

--- a/lib/ember_rails.rb
+++ b/lib/ember_rails.rb
@@ -21,35 +21,24 @@ module Ember
       end
 
       initializer "ember_rails.setup_vendor", :after => "ember_rails.setup", :group => :all do |app|
-        if variant = app.config.ember.variant || ::Rails.env.test?
-          # test environments should default to development
-          variant ||= :development
-          # Copy over the desired ember, ember-data, and handlebars bundled in
-          # ember-source, ember-data-source, and handlebars-source to a tmp folder.
-          tmp_path = app.root.join("tmp/ember-rails")
-          ext = variant == :production ? ".prod.js" : ".js"
-          FileUtils.mkdir_p(tmp_path)
-          FileUtils.cp(::Ember::Source.bundled_path_for("ember#{ext}"), tmp_path.join("ember.js"))
-          FileUtils.cp(::Ember::Data::Source.bundled_path_for("ember-data#{ext}"), tmp_path.join("ember-data.js"))
-          app.assets.append_path(tmp_path)
+        variant = app.config.ember.variant || ::Rails.env.production? ? :production : :development
 
-          # Make the handlebars.js and handlebars.runtime.js bundled
-          # in handlebars-source available.
-          app.assets.append_path(File.expand_path('../', ::Handlebars::Source.bundled_path))
+        # Copy over the desired ember, ember-data, and handlebars bundled in
+        # ember-source, ember-data-source, and handlebars-source to a tmp folder.
+        tmp_path = app.root.join("tmp/ember-rails")
+        ext = variant == :production ? ".prod.js" : ".js"
+        FileUtils.mkdir_p(tmp_path)
+        FileUtils.cp(::Ember::Source.bundled_path_for("ember#{ext}"), tmp_path.join("ember.js"))
+        FileUtils.cp(::Ember::Data::Source.bundled_path_for("ember-data#{ext}"), tmp_path.join("ember-data.js"))
+        app.assets.append_path(tmp_path)
 
-          # Allow a local variant override
-          ember_path = app.root.join("vendor/assets/ember/#{variant}")
-          app.assets.prepend_path(ember_path.to_s) if ember_path.exist?
+        # Make the handlebars.js and handlebars.runtime.js bundled
+        # in handlebars-source available.
+        app.assets.append_path(File.expand_path('../', ::Handlebars::Source.bundled_path))
 
-        else
-          warn "No ember.js variant was specified in your config environment."
-          warn "You can set a specific variant in your application config in "
-          warn "order for sprockets to locate ember's assets:"
-          warn ""
-          warn "    config.ember.variant = :development"
-          warn ""
-          warn "Valid values are :development and :production"
-        end
+        # Allow a local variant override
+        ember_path = app.root.join("vendor/assets/ember/#{variant}")
+        app.assets.prepend_path(ember_path.to_s) if ember_path.exist?
       end
 
       initializer "ember_rails.es5_default", :group => :all do |app|

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -39,8 +39,6 @@ module Dummy
 
     # Enable the asset pipeline
     config.assets.enabled = true
-
-    config.ember.variant = :production
   end
 end
 


### PR DESCRIPTION
Still allows overriding via `config/application.rb` (or environment specific
files), but now we will use an appropriate default configuration.
