### PR TITLE
root path replacement bug in handlebar template_path fixed

### DIFF
--- a/lib/ember/handlebars/template.rb
+++ b/lib/ember/handlebars/template.rb
@@ -92,13 +92,14 @@ module Ember
           end
         else
           unless root.empty?
-            path.sub!(/#{Regexp.quote(root)}\/?/, '')
+            path.sub!(/#{Regexp.quote(root)}\//, '')
           end
         end
 
         path = path.split('/')
 
         path.join(configuration.templates_path_separator)
+
       end
 
       def configuration


### PR DESCRIPTION
The bug occur when 'template_path' method did to replace the content of root variable with blank and  emberj resulted template name contains the address too, so 'Ember.TEMPLATES'  will have the wrong template name.

NOTE: This bug happens if you use emberjs inside a directoy like 'app/assets/javascript/myengine/'
