### PR TITLE
Require jQuery from the default bootstrap template.

### DIFF
--- a/lib/generators/templates/application.js
+++ b/lib/generators/templates/application.js
@@ -1,3 +1,4 @@
+//= require jquery
 //= require handlebars
 //= require ember
 //= require ember-data


### PR DESCRIPTION
This is still completely customizable, but I believe that 90% of the time this
is the correct choice. `jquery-rails` is one of the default gems for a new
Rails install.
