### PR TITLE
EmberScript Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ rake tmp:clear
 ```
 
 ## For CoffeeScript support
+
 1. Add coffee-rails to the Gemfile
 ```ruby
 gem 'coffee-rails'
@@ -68,6 +69,24 @@ Ember-rails include some flags options for bootstrap generator:
 --javascript-engine  # engine for javascript (js or coffee)
 --app-name or -n # custom ember app name
 ```
+
+### For EmberScript support
+
+[EmberScript](http://www.emberscript.com) is a dialect of CoffeeScript
+with extra support for computed properties (which do not have to be
+explicitly declared), the `class` / `extends` syntax, and extra syntax
+to support observers and mixins.
+
+To get EmberScript support, make sure you have the following in your
+Gemfile:
+
+```ruby
+gem 'ember_script-rails', :github => 'ghempton/ember-script-rails'
+```
+
+You can now use the flag `--javascript-engine=em` to specify EmberScript
+assets in your generators, but all of the generators will default to
+using an EmberScript variant first.
 
 ## Configuration Options
 

--- a/lib/generators/templates/app.js.em
+++ b/lib/generators/templates/app.js.em
@@ -1,0 +1,9 @@
+#= require ./store
+#= require_tree ./models
+#= require_tree ./controllers
+#= require_tree ./views
+#= require_tree ./helpers
+#= require_tree ./templates
+#= require_tree ./routes
+#= require ./router
+#= require_self

--- a/lib/generators/templates/application.js.em
+++ b/lib/generators/templates/application.js.em
@@ -1,0 +1,8 @@
+#= require handlebars
+#= require ember
+#= require ember-data
+#= require_self
+#= require <%= application_name.underscore %>
+
+# for more details see: http://emberjs.com/guides/application/
+window.<%= application_name.camelize %> = Ember.Application.create()

--- a/lib/generators/templates/array_controller.js.em
+++ b/lib/generators/templates/array_controller.js.em
@@ -1,0 +1,3 @@
+# for more details see: http://emberjs.com/guides/controllers/
+
+class <%= application_name.camelize %>.<%= class_name %>Controller extends Ember.ArrayController

--- a/lib/generators/templates/component.js.em
+++ b/lib/generators/templates/component.js.em
@@ -1,0 +1,6 @@
+# for more details see: http://emberjs.com/guides/components/
+
+<%= application_name.camelize %>.<%= class_name %>Component = Ember.Component.extend({
+
+})
+

--- a/lib/generators/templates/controller.js.em
+++ b/lib/generators/templates/controller.js.em
@@ -1,0 +1,3 @@
+# for more details see: http://emberjs.com/guides/controllers/
+
+class <%= application_name.camelize %>.<%= class_name %>Controller extends Ember.Controller

--- a/lib/generators/templates/model.js.em
+++ b/lib/generators/templates/model.js.em
@@ -1,0 +1,12 @@
+# for more details see: http://emberjs.com/guides/models/defining-models/
+
+class <%= application_name.camelize %>.<%= class_name %> extends DS.Model
+<% attributes.each do |attribute| -%>
+  <%= attribute[:name].camelize(:lower) %>: <%=
+  if %w(references belongs_to).member?(attribute[:type])
+    "DS.belongsTo '%s.%s'" % [application_name.camelize, attribute[:name].camelize]
+  else
+    "DS.attr '%s'" % attribute[:type]
+  end
+  %>
+<% end -%>

--- a/lib/generators/templates/object_controller.js.em
+++ b/lib/generators/templates/object_controller.js.em
@@ -1,0 +1,3 @@
+# for more details see: http://emberjs.com/guides/controllers/
+
+class <%= application_name.camelize %>.<%= class_name %>Controller extends Ember.ObjectController

--- a/lib/generators/templates/route.js.em
+++ b/lib/generators/templates/route.js.em
@@ -1,0 +1,3 @@
+# For more information see: http://emberjs.com/guides/routing/
+
+class <%= application_name.camelize %>.<%= class_name.camelize %>Route extends Ember.Route

--- a/lib/generators/templates/router.js.em
+++ b/lib/generators/templates/router.js.em
@@ -1,0 +1,5 @@
+# For more information see: http://emberjs.com/guides/routing/
+
+<%= application_name.camelize %>.Router.map ->
+  # @resource('posts')
+

--- a/lib/generators/templates/store.js.em
+++ b/lib/generators/templates/store.js.em
@@ -1,0 +1,7 @@
+# http://emberjs.com/guides/models/using-the-store/
+
+class <%= application_name.camelize %>.Store extends DS.Store
+  # Override the default adapter with the `DS.ActiveModelAdapter` which
+  # is built to work nicely with the ActiveModel::Serializers gem.
+  adapter: '_ams'
+

--- a/lib/generators/templates/view.js.em
+++ b/lib/generators/templates/view.js.em
@@ -1,0 +1,4 @@
+# for more details see: http://emberjs.com/guides/views/
+
+class <%= application_name.camelize %>.<%= class_name.camelize %>View extends Ember.View
+  templateName: '<%= handlebars_template_path %>'

--- a/test/generators/bootstrap_generator_engine_test.rb
+++ b/test/generators/bootstrap_generator_engine_test.rb
@@ -40,7 +40,7 @@ class BootstrapGeneratorEngineTest < Rails::Generators::TestCase
     assert_new_dirs(:skip_git => true)
   end
 
-  %w(js coffee).each do |engine|
+  %w(js coffee em).each do |engine|
 
     test "create bootstrap in a rails engine with #{engine}" do
       run_generator ["--javascript-engine=#{engine}"]

--- a/test/generators/bootstrap_generator_test.rb
+++ b/test/generators/bootstrap_generator_test.rb
@@ -32,7 +32,7 @@ class BootstrapGeneratorTest < Rails::Generators::TestCase
     assert_new_dirs(:skip_git => true)
   end
 
-  %w(js coffee).each do |engine|
+  %w(js coffee em).each do |engine|
 
     test "create bootstrap with #{engine} engine" do
       run_generator ["--javascript-engine=#{engine}"]

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -22,7 +22,7 @@ class ComponentGeneratorTest < Rails::Generators::TestCase
     copy_directory "config"
   end
 
-  %w(js coffee).each do |engine|
+  %w(js coffee em).each do |engine|
 
     test "default_component with #{engine} engine" do
       run_generator ["PostChart","--javascript-engine=#{engine}"]

--- a/test/generators/controller_generator_test.rb
+++ b/test/generators/controller_generator_test.rb
@@ -23,7 +23,7 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
     copy_directory "config"
   end
 
-  %w(js coffee).each do |engine|
+  %w(js coffee em).each do |engine|
 
     test "array_controller with #{engine} engine" do
 

--- a/test/generators/model_generator_test.rb
+++ b/test/generators/model_generator_test.rb
@@ -23,7 +23,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     copy_directory "config"
   end
 
-  %w(js coffee).each do |engine|
+  %w(js coffee em).each do |engine|
 
 
     test "create model with #{engine} engine" do

--- a/test/generators/resource_generator_test.rb
+++ b/test/generators/resource_generator_test.rb
@@ -7,7 +7,7 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
   setup :prepare_destination
 
 
-  %w(js coffee).each do |engine|
+  %w(js coffee em).each do |engine|
 
     test "create view with #{engine} engine" do
       run_generator ["post", "--javascript-engine=#{engine}"]

--- a/test/generators/template_generator_test.rb
+++ b/test/generators/template_generator_test.rb
@@ -7,7 +7,7 @@ class TemplateGeneratorTest < Rails::Generators::TestCase
   setup :prepare_destination
 
 
-  %w(js coffee).each do |engine|
+  %w(js coffee em).each do |engine|
     test "template with #{engine} as current engine" do
       run_generator ["post", "--javascript-engine", engine]
       assert_file "app/assets/javascripts/templates/post.handlebars"

--- a/test/generators/view_generator_test.rb
+++ b/test/generators/view_generator_test.rb
@@ -23,7 +23,7 @@ class ViewGeneratorTest < Rails::Generators::TestCase
   end
 
 
-  %w(js coffee).each do |engine|
+  %w(js coffee em).each do |engine|
 
     test "create view with #{engine} engine" do
       run_generator ["post", "--javascript-engine=#{engine}"]


### PR DESCRIPTION
Building on the existing code for CoffeeScript generators, this PR along with [this contribution to ember-script-rails](https://github.com/ghempton/ember-script-rails/pull/3) allows for EmberScript files to be generated in place of CoffeeScript. EmberScript is a CoffeeScript dialect that allows for better interoperability with Ember's somewhat unusual architecture. Read more at http://www.emberscript.com.

This shouldn't break anything as-is, it just won't work unless ember-script-rails sets the javascript_engine to `:em`.
