### PR TITLE
Fix operator precedence for setting ember variant to Rails environment

### DIFF
--- a/lib/ember_rails.rb
+++ b/lib/ember_rails.rb
@@ -21,7 +21,7 @@ module Ember
       end
 
       initializer "ember_rails.setup_vendor", :after => "ember_rails.setup", :group => :all do |app|
-        variant = app.config.ember.variant || ::Rails.env.production? ? :production : :development
+        variant = app.config.ember.variant || (::Rails.env.production? ? :production : :development)
 
         # Copy over the desired ember, ember-data, and handlebars bundled in
         # ember-source, ember-data-source, and handlebars-source to a tmp folder.


### PR DESCRIPTION
The recent change to use the Rails environment to determine the ember variant has broken operator precedence. The line was being treated as follows:

```
variant = (app.config.ember.variant || ::Rails.env.production?) ? :production : :development
```

which means the only time a development build will be used is when there is **not a** `config.ember.variant = :development` line in your configuration and you're running in Rails' development mode -- Setting the variant to any truthy value (which includes `:development`) would result in the `:production` variant being used.

This can be fixed by wrapping the Rails env check in parentheses instead (which is what I'm doing), though you could also use Ruby's `or` operator instead of `||` since its precedence would cause `app.config.ember.variant` to be used immediately (without ever checking `Rails.env`).
