### PR TITLE
Fixed bootstrap generator for Rails engines.

### DIFF
--- a/lib/generators/ember/generator_helpers.rb
+++ b/lib/generators/ember/generator_helpers.rb
@@ -49,7 +49,9 @@ module Ember
       end
 
       def configuration
-        ::Rails.configuration.ember
+        if defined?(::Rails) && ::Rails.configuration
+          ::Rails.configuration.ember
+        end
       end
     end
   end


### PR DESCRIPTION
The generator helpers for determining the ember_path and application_name cause an exception when run inside an engine. Inside the engine, `::Rails.configuration` is undefined. This check, however, is done before the engine check in these methods preventing the correct value from ever being returned.

This might be related to issue #310.
