### PR TITLE
Fix typo in install generator help message

### DIFF
--- a/lib/generators/ember/install_generator.rb
+++ b/lib/generators/ember/install_generator.rb
@@ -97,8 +97,8 @@ module Ember
       end
 
       def check_options
-        if options.head? 
-          say('WARNING: --head option is deprecated in favor of --channel=cannary' , :yellow)
+        if options.head?
+          say('WARNING: --head option is deprecated in favor of --channel=canary' , :yellow)
         end
         if options.head? && options.channel?
           say 'ERROR: conflicting options. --head and --channel. Use either --head or --channel=<channel>', :red

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -57,7 +57,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   test "with options --head it should show a deprecation message" do
     VCR.use_cassette('fetch_ember_canary') do
       output = run_generator ['--head']
-      assert( output.include?('--head option is deprecated in favor of --channel=cannary'))
+      assert( output.include?('--head option is deprecated in favor of --channel=canary'))
     end
   end
 


### PR DESCRIPTION
Help message was asking to use --channel=cannary 
instead of the --head option
when it should be --channel=canary.
