### PR TITLE
Optional resource generating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.15.0
+
+  - Rails resource generator only overrides if --ember option is given
+
 ## 0.14.0 (Nov 4, 2013)
 
   - Added support for most recent stable releases of ember js and ember data.

--- a/lib/generators/ember/resource_override.rb
+++ b/lib/generators/ember/resource_override.rb
@@ -6,23 +6,27 @@ require "generators/ember/view_generator"
 module Rails
   module Generators
     ResourceGenerator.class_eval do
+      class_option :ember, aliases: '-e', desc: 'force ember resource to generate', optional: true, type: 'boolean', default: false, banner: '--ember'
+
       def add_ember
-        say_status :invoke, "ember:model", :white
-        with_padding do
-          invoke "ember:model"
-        end
+        if options.ember
+          say_status :invoke, "ember:model", :white
+          with_padding do
+            invoke "ember:model"
+          end
 
-        say_status :invoke, "ember controller and view (singular)", :white
-        with_padding do
-          invoke "ember:view", [singular_name], :object => true
-        end
+          say_status :invoke, "ember controller and view (singular)", :white
+          with_padding do
+            invoke "ember:view", [singular_name], :object => true
+          end
 
-        @_invocations[Ember::Generators::ControllerGenerator].delete "create_controller_files"
-        @_invocations[Ember::Generators::ViewGenerator].delete "create_view_files"
+          @_invocations[Ember::Generators::ControllerGenerator].delete "create_controller_files"
+          @_invocations[Ember::Generators::ViewGenerator].delete "create_view_files"
 
-        say_status :invoke, "ember controller and view (plural)", :white
-        with_padding do
-          invoke "ember:view", [plural_name], :array => true
+          say_status :invoke, "ember controller and view (plural)", :white
+          with_padding do
+            invoke "ember:view", [plural_name], :array => true
+          end
         end
       end
     end


### PR DESCRIPTION
Rails resource generator won't generate ember by default. `--ember` is
required to force ember generation

```
rails generate post title:string --ember
```
