### PR TITLE
Define App.ApplicationAdapter instead of using the container key

### DIFF
--- a/lib/generators/templates/store.js
+++ b/lib/generators/templates/store.js
@@ -1,7 +1,11 @@
 // http://emberjs.com/guides/models/using-the-store/
 
 <%= application_name.camelize %>.Store = DS.Store.extend({
-  // Override the default adapter with the `DS.ActiveModelAdapter` which
-  // is built to work nicely with the ActiveModel::Serializers gem.
-  adapter: '_ams'
+
+});
+
+// Override the default adapter with the `DS.ActiveModelAdapter` which
+// is built to work nicely with the ActiveModel::Serializers gem.
+<%= application_name.camelize %>.ApplicationAdapter = DS.ActiveModelAdapter.extend({
+
 });

--- a/lib/generators/templates/store.js.coffee
+++ b/lib/generators/templates/store.js.coffee
@@ -1,6 +1,11 @@
 # http://emberjs.com/guides/models/using-the-store/
 
-<%= application_name.camelize %>.Store = DS.Store.extend
-  # Override the default adapter with the `DS.ActiveModelAdapter` which
-  # is built to work nicely with the ActiveModel::Serializers gem.
-  adapter: '_ams'
+<%= application_name.camelize %>.Store = DS.Store.extend({
+
+})
+
+# Override the default adapter with the `DS.ActiveModelAdapter` which
+# is built to work nicely with the ActiveModel::Serializers gem.
+<%= application_name.camelize %>.ApplicationAdapter = DS.ActiveModelAdapter.extend({
+
+})

--- a/lib/generators/templates/store.js.em
+++ b/lib/generators/templates/store.js.em
@@ -1,7 +1,7 @@
 # http://emberjs.com/guides/models/using-the-store/
 
 class <%= application_name.camelize %>.Store extends DS.Store
-  # Override the default adapter with the `DS.ActiveModelAdapter` which
-  # is built to work nicely with the ActiveModel::Serializers gem.
-  adapter: '_ams'
 
+# Override the default adapter with the `DS.ActiveModelAdapter` which
+# is built to work nicely with the ActiveModel::Serializers gem.
+class <%= application_name.camelize %>.ApplicationAdapter extends DS.ActiveModelAdapter

--- a/test/generators/bootstrap_generator_engine_test.rb
+++ b/test/generators/bootstrap_generator_engine_test.rb
@@ -71,6 +71,7 @@ class BootstrapGeneratorEngineTest < Rails::Generators::TestCase
 
       run_generator
       assert_file "#{ember_path}/store.js", /MyApp\.Store/
+      assert_file "#{ember_path}/store.js", /MyApp\.ApplicationAdapter = DS\.ActiveModelAdapter/
       assert_file "#{ember_path}/router.js", /MyApp\.Router\.map/
     ensure
       ::Rails.configuration.ember.app_name = old

--- a/test/generators/bootstrap_generator_test.rb
+++ b/test/generators/bootstrap_generator_test.rb
@@ -98,6 +98,7 @@ class BootstrapGeneratorTest < Rails::Generators::TestCase
 
       run_generator %w(ember)
       assert_file "#{ember_path}/store.js", /MyApp\.Store/
+      assert_file "#{ember_path}/store.js", /MyApp\.ApplicationAdapter = DS\.ActiveModelAdapter/
       assert_file "#{ember_path}/router.js", /MyApp\.Router\.map/
     ensure
       ::Rails.configuration.ember.app_name = old


### PR DESCRIPTION
Didn't think it required a separate file, but welcome to other opinions

cc @stefanpenner
