### PR TITLE
Ensure jj-abrams ember-data is used.

### DIFF
--- a/ember-rails.gemspec
+++ b/ember-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails", ">= 1.0.17"
   s.add_dependency "ember-source", ">= 1.1.0"
   s.add_dependency "handlebars-source", "> 1.0.0"
-  s.add_dependency "ember-data-source"
+  s.add_dependency "ember-data-source", '>= 1.0.0.beta.5'
 
   s.add_development_dependency "bundler", [">= 1.2.2"]
   s.add_development_dependency "appraisal"


### PR DESCRIPTION
Rubygems by default was using `0.14` since it was not marked as a 
beta/pre-release version. This is a HORRIBLE thing since the generators in
ember-rails expect specific changes from the reboot (e.g. ActiveModelAdapter).
