### PR TITLE
Remove nonexistent links

### DIFF
--- a/lib/generators/templates/store.js
+++ b/lib/generators/templates/store.js
@@ -1,5 +1,3 @@
-// http://emberjs.com/guides/models/using-the-store/
-
 <%= application_name.camelize %>.Store = DS.Store.extend({
 
 });

--- a/lib/generators/templates/store.js.em
+++ b/lib/generators/templates/store.js.em
@@ -1,5 +1,3 @@
-# http://emberjs.com/guides/models/using-the-store/
-
 class <%= application_name.camelize %>.Store extends DS.Store
 
 # Override the default adapter with the `DS.ActiveModelAdapter` which


### PR DESCRIPTION
- `using-the-store` no longer exists on the Ember.js website
