### PR TITLE
adding support for CSRF Token to DS.RESTAdapter in store

### DIFF
--- a/lib/generators/templates/store.js
+++ b/lib/generators/templates/store.js
@@ -7,3 +7,14 @@
 <%= application_name.camelize %>.ApplicationAdapter = DS.ActiveModelAdapter.extend({
 
 });
+
+
+// Adds X-CSRF-Token to all REST requests.
+// Allows for the use of Rails protect_from_forgery
+// The CSRF Token is normally found in app/views/layouts/application.html.*
+// inserted with the rails helper: "csrf_meta_tags"
+DS.RESTAdapter.reopen({
+  headers: {
+    "X-CSRF-Token": $('meta[name="csrf-token"]').attr('content')
+  }
+});

--- a/lib/generators/templates/store.js.coffee
+++ b/lib/generators/templates/store.js.coffee
@@ -10,3 +10,12 @@
 <%= application_name.camelize %>.ApplicationAdapter = DS.ActiveModelAdapter.extend({
 
 })
+
+# Adds X-CSRF-Token to all REST requests.
+# Allows for the use of Rails protect_from_forgery
+# The CSRF Token is normally found in app/views/layouts/application.html.*
+# inserted with the rails helper: "csrf_meta_tags"
+DS.RESTAdapter.reopen(
+  headers:
+    "X-CSRF-Token": $('meta[name="csrf-token"]').attr('content')
+)

--- a/lib/generators/templates/store.js.em
+++ b/lib/generators/templates/store.js.em
@@ -3,3 +3,12 @@ class <%= application_name.camelize %>.Store extends DS.Store
 # Override the default adapter with the `DS.ActiveModelAdapter` which
 # is built to work nicely with the ActiveModel::Serializers gem.
 class <%= application_name.camelize %>.ApplicationAdapter extends DS.ActiveModelAdapter
+
+# Adds X-CSRF-Token to all REST requests.
+# Allows for the use of Rails protect_from_forgery
+# The CSRF Token is normally found in app/views/layouts/application.html.*
+# inserted with the rails helper: "csrf_meta_tags"
+DS.RESTAdapter.reopen(
+  headers:
+    "X-CSRF-Token": $('meta[name="csrf-token"]').attr('content')
+)


### PR DESCRIPTION
Adding to DS.RESTAdapter the CSRF Token so that requests will work with Rails's protect_from_forgery. I have tested the generator on my machine. Here is a discussion that I had about how to support CSRF tokens:  http://discuss.emberjs.com/t/rails-cant-verify-csrf-token-authenticity-with-ember-data/4110/10
