### PR TITLE
Move note for command line option to the end of ember-script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,17 +66,6 @@ Run the bootstrap generator in step 4 with an extra flag instead:
 rails g ember:bootstrap -g --javascript-engine coffee
 ```
 
-Note:
-
-Ember-rails include some flags options for bootstrap generator:
-
-```
---ember-path or -d # custom ember path
---skip-git or -g # skip git keeps
---javascript-engine  # engine for javascript (js or coffee)
---app-name or -n # custom ember app name
-```
-
 ## For EmberScript support
 
 [EmberScript](http://www.emberscript.com) is a dialect of CoffeeScript
@@ -94,6 +83,17 @@ gem 'ember_script-rails', :github => 'ghempton/ember-script-rails'
 You can now use the flag `--javascript-engine=em` to specify EmberScript
 assets in your generators, but all of the generators will default to
 using an EmberScript variant first.
+
+Note:
+
+Ember-rails include some flags options for bootstrap generator:
+
+```
+--ember-path or -d # custom ember path
+--skip-git or -g # skip git keeps
+--javascript-engine  # engine for javascript (js, coffee or em)
+--app-name or -n # custom ember app name
+```
 
 ## Configuration Options
 


### PR DESCRIPTION
The outline should be:

```
* For CoffeeScript support
* For EmberScript support
  * Note
```

not:

```
* For CoffeeScript support
  * Note
* For EmberScript support
```
