### PR TITLE
Fix to update generated relation name for model generator

### DIFF
--- a/lib/generators/templates/model.js
+++ b/lib/generators/templates/model.js
@@ -4,7 +4,7 @@
 <% attributes.each_with_index do |attribute, idx| -%>
   <%= attribute[:name].camelize(:lower) %>: <%=
   if %w(references belongs_to).member?(attribute[:type])
-    "DS.belongsTo('%s.%s')" % [application_name.camelize, attribute[:name].camelize]
+    "DS.belongsTo('%s')" % attribute[:name].camelize(:lower)
   else
     "DS.attr('%s')" % attribute[:type]
   end

--- a/lib/generators/templates/model.js.coffee
+++ b/lib/generators/templates/model.js.coffee
@@ -4,7 +4,7 @@
 <% attributes.each do |attribute| -%>
   <%= attribute[:name].camelize(:lower) %>: <%=
   if %w(references belongs_to).member?(attribute[:type])
-    "DS.belongsTo '%s.%s'" % [application_name.camelize, attribute[:name].camelize]
+    "DS.belongsTo '%s'" % attribute[:name].camelize(:lower)
   else
     "DS.attr '%s'" % attribute[:type]
   end

--- a/lib/generators/templates/model.js.em
+++ b/lib/generators/templates/model.js.em
@@ -4,7 +4,7 @@ class <%= application_name.camelize %>.<%= class_name %> extends DS.Model
 <% attributes.each do |attribute| -%>
   <%= attribute[:name].camelize(:lower) %>: <%=
   if %w(references belongs_to).member?(attribute[:type])
-    "DS.belongsTo '%s.%s'" % [application_name.camelize, attribute[:name].camelize]
+    "DS.belongsTo '%s'" % attribute[:name].camelize(:lower)
   else
     "DS.attr '%s'" % attribute[:type]
   end

--- a/test/generators/model_generator_test.rb
+++ b/test/generators/model_generator_test.rb
@@ -24,8 +24,6 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   end
 
   %w(js coffee em).each do |engine|
-
-
     test "create model with #{engine} engine" do
       run_generator ["post", "title:string", "--javascript-engine=#{engine}"]
       assert_file "app/assets/javascripts/models/post.js.#{engine}".sub('.js.js','.js')
@@ -34,6 +32,12 @@ class ModelGeneratorTest < Rails::Generators::TestCase
     test "create namespaced model with #{engine} engine" do
       run_generator ["post/doineedthis", "title:string", "--javascript-engine=#{engine}"]
       assert_file "app/assets/javascripts/models/post/doineedthis.js.#{engine}".sub('.js.js','.js'), /PostDoineedthis/
+    end
+
+    test "create attribute with #{engine} engine" do
+      run_generator ["comment", "post:references", "body:string", "--javascript-engine=#{engine}"]
+      assert_file "app/assets/javascripts/models/comment.js.#{engine}".sub('.js.js','.js'), /body: DS.attr/
+      assert_file "app/assets/javascripts/models/comment.js.#{engine}".sub('.js.js','.js'), /post: DS.belongsTo.+post/
     end
   end
 


### PR DESCRIPTION
From Ember Data 1.0.0.beta,
the relation should be defined as underscored name.

Before:

``` js
App.Comment = DS.Model.extend({
  post: DS.belongsTo('App.Post')
});
```

After:

``` js
App.Comment = DS.Model.extend({
  post: DS.belongsTo('post')
});
```
