### PR TITLE
Pass options when resource generator invokes view generator

### DIFF
--- a/lib/generators/ember/resource_override.rb
+++ b/lib/generators/ember/resource_override.rb
@@ -6,6 +6,12 @@ require "generators/ember/view_generator"
 module Rails
   module Generators
     ResourceGenerator.class_eval do
+
+      class_option :javascript_engine, :desc => "Engine for JavaScripts"
+      class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "Custom ember app path"
+      class_option :with_template, :type => :boolean, :default => false, :desc => "Create template for this view"
+      class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
+
       def add_ember
         say_status :invoke, "ember:model", :white
         with_padding do
@@ -14,7 +20,7 @@ module Rails
 
         say_status :invoke, "ember controller and view (singular)", :white
         with_padding do
-          invoke "ember:view", [singular_name], :object => true
+          invoke "ember:view", [singular_name], options.merge(:object => true)
         end
 
         @_invocations[Ember::Generators::ControllerGenerator].delete "create_controller_files"
@@ -22,7 +28,7 @@ module Rails
 
         say_status :invoke, "ember controller and view (plural)", :white
         with_padding do
-          invoke "ember:view", [plural_name], :array => true
+          invoke "ember:view", [plural_name], options.merge(:array => true)
         end
       end
     end


### PR DESCRIPTION
I noticed the Ember additions to the rails resource generator weren't fully respecting the `--javascript-engine` option, so I was getting coffescript views when I wanted javascript.

Eg

```
$ be rails g resource person name:string --javascript-engine js
      invoke  active_record
      ... (omitted)
      invoke  ember:model
      create    app/assets/javascripts/models/person.js
      invoke  ember controller and view (singular)
      create    app/assets/javascripts/views/person_view.js.coffee
      invoke  ember controller and view (plural)
      create    app/assets/javascripts/views/people_view.js.coffee
```

creates `person_view.js.coffee` and `people_view.js.coffee`. 

I fixed it by adding the ember specific `class_option`s into `resource_override.rb`, and merging in the options when the view generators are invoked. Its working now, but let me know if there's a better way to fix it and I'd be happy to update the PR
