### PR TITLE
Change App.Store to App.ApplicationStore

### DIFF
--- a/lib/generators/templates/store.js
+++ b/lib/generators/templates/store.js
@@ -1,4 +1,4 @@
-<%= application_name.camelize %>.Store = DS.Store.extend({
+<%= application_name.camelize %>.ApplicationStore = DS.Store.extend({
 
 });
 

--- a/lib/generators/templates/store.js.coffee
+++ b/lib/generators/templates/store.js.coffee
@@ -1,7 +1,7 @@
 # http://emberjs.com/guides/models/#toc_store
 # http://emberjs.com/guides/models/pushing-records-into-the-store/
 
-<%= application_name.camelize %>.Store = DS.Store.extend({
+<%= application_name.camelize %>.ApplicationStore = DS.Store.extend({
 
 })
 

--- a/lib/generators/templates/store.js.em
+++ b/lib/generators/templates/store.js.em
@@ -1,4 +1,4 @@
-class <%= application_name.camelize %>.Store extends DS.Store
+class <%= application_name.camelize %>.ApplicationStore extends DS.Store
 
 # Override the default adapter with the `DS.ActiveModelAdapter` which
 # is built to work nicely with the ActiveModel::Serializers gem.

--- a/test/generators/bootstrap_generator_engine_test.rb
+++ b/test/generators/bootstrap_generator_engine_test.rb
@@ -59,7 +59,7 @@ class BootstrapGeneratorEngineTest < Rails::Generators::TestCase
 
     test "create bootstrap in a rails engine with #{engine} and custom app name" do
       run_generator ["--javascript-engine=#{engine}", "-n", "MyEngine"]
-      assert_file "#{ember_path}/store.js.#{engine}".sub('.js.js','.js'), /MyEngine\.Store/
+      assert_file "#{ember_path}/store.js.#{engine}".sub('.js.js','.js'), /MyEngine\.ApplicationStore/
       assert_file "#{ember_path}/router.js.#{engine}".sub('.js.js','.js'), /MyEngine\.Router\.map/
       assert_file "#{ember_path}/my_engine.js.#{engine}".sub('.js.js','.js')
     end

--- a/test/generators/bootstrap_generator_test.rb
+++ b/test/generators/bootstrap_generator_test.rb
@@ -55,7 +55,7 @@ class BootstrapGeneratorTest < Rails::Generators::TestCase
 
     test "create bootstrap with #{engine} and custom app name" do
       run_generator ["--javascript-engine=#{engine}", "-n", "MyApp"]
-      assert_file "#{ember_path}/store.js.#{engine}".sub('.js.js','.js'), /MyApp\.Store/
+      assert_file "#{ember_path}/store.js.#{engine}".sub('.js.js','.js'), /MyApp\.ApplicationStore/
       assert_file "#{ember_path}/router.js.#{engine}".sub('.js.js','.js'), /MyApp\.Router\.map/
       assert_file "#{ember_path}/my_app.js.#{engine}".sub('.js.js','.js')
     end
@@ -97,7 +97,7 @@ class BootstrapGeneratorTest < Rails::Generators::TestCase
       old, ::Rails.configuration.ember.app_name = ::Rails.configuration.ember.app_name, 'MyApp'
 
       run_generator %w(ember)
-      assert_file "#{ember_path}/store.js", /MyApp\.Store/
+      assert_file "#{ember_path}/store.js", /MyApp\.ApplicationStore/
       assert_file "#{ember_path}/store.js", /MyApp\.ApplicationAdapter = DS\.ActiveModelAdapter/
       assert_file "#{ember_path}/router.js", /MyApp\.Router\.map/
     ensure


### PR DESCRIPTION
App.Store has been deprecated. This commit changes all references of MyApp.Store to MyApp.ApplicationStore and resolves #367.
