### PR TITLE
Fix handlebars amd output compatibility with IE8

### DIFF
--- a/lib/ember/handlebars/template.rb
+++ b/lib/ember/handlebars/template.rb
@@ -37,7 +37,7 @@ module Ember
         if configuration.output_type == :amd
           target = amd_template_target(scope)
 
-          "define('#{target}', ['exports'], function(__exports__){ __exports__.default = #{template} });"
+          "define('#{target}', ['exports'], function(__exports__){ __exports__['default'] = #{template} });"
         else
           target = global_template_target(scope)
 

--- a/test/hjstemplate_test.rb
+++ b/test/hjstemplate_test.rb
@@ -102,7 +102,7 @@ class HjsTemplateTest < IntegrationTest
       template = Ember::Handlebars::Template.new template_path.to_s
       asset = app.assets.attributes_for(template_path)
 
-      assert_match /define\('appkit\/templates\/test', \['exports'\], function\(__exports__\)\{ __exports__.default = Ember\.Handlebars\.template\(function .*"test"/m, template.render(asset)
+      assert_match /define\('appkit\/templates\/test', \['exports'\], function\(__exports__\)\{ __exports__\['default'\] = Ember\.Handlebars\.template\(function .*"test"/m, template.render(asset)
     end
   end
 


### PR DESCRIPTION
`default` is a reserved keyword in IE8 which causes "expected identifier" errors if used. This PR fixes compatibility.
