### PR TITLE
Remove unnecessary .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/ember"]
-	path = vendor/ember
-	url = https://github.com/emberjs/ember.js.git


### PR DESCRIPTION
Currently, Ember.js is bundled as ember-source gem.
