### PR TITLE
Suppress deprecation warning for appraisal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-before_script: "bundle exec rake appraisal:install"
+before_script: "bundle exec appraisal install"
 script: "bundle exec rake appraisal test"

--- a/ember-rails.gemspec
+++ b/ember-rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ember-data-source", '>= 1.0.0.beta.5'
 
   s.add_development_dependency "bundler", [">= 1.2.2"]
-  s.add_development_dependency "appraisal"
+  s.add_development_dependency "appraisal", ">= 1.0.0"
   s.add_development_dependency "tzinfo"
 
   s.add_development_dependency "sprockets-rails"


### PR DESCRIPTION
```
`rake appraisal:install` task is deprecated and will be removed soon. Please use `appraisal install`.
```
