### PR TITLE
Fix generator for `--channel=release`

### DIFF
--- a/lib/generators/ember/install_generator.rb
+++ b/lib/generators/ember/install_generator.rb
@@ -78,7 +78,7 @@ module Ember
         # temporarily using a variable here until a stable release of
         # ember-data is released so that installing with ember-data
         # *just works*.
-        chan = if channel == :release
+        chan = if channel.to_s == 'release'
           say_status("warning:", 'Ember Data is not available on the :release channel. Falling back to beta channel.' , :yellow)
           :beta
         else

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -37,20 +37,19 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   end
 
   test "without any options it load the release channel" do
-
     VCR.use_cassette('fetch_ember_release') do
-      run_generator 
-      assert_all_ember_files
-      # assert_all_ember_data_files TODO: Remove after ember data is released
+      run_generator
     end
+    assert_all_ember_files
+    assert_all_ember_data_files
   end
 
   test "with options --head it should load the canary ember-data & ember files" do
     VCR.use_cassette('fetch_ember_canary') do
       run_generator ['--head']
-      assert_all_ember_files
-      assert_all_ember_data_files
     end
+    assert_all_ember_files
+    assert_all_ember_data_files
   end
 
   test "with options --head it should show a deprecation message" do
@@ -64,26 +63,26 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   test "with options channel=release it should load the release ember-data & ember files" do
     VCR.use_cassette('fetch_ember_release') do
       run_generator ['--channel=release']
-      assert_all_ember_files
-      # assert_all_ember_data_files TODO: Remove after ember data is released
     end
+    assert_all_ember_files
+    assert_all_ember_data_files
   end
 
 
   test "with options channel=beta it should load the beta ember-data & ember files" do
     VCR.use_cassette('fetch_ember_beta') do
       run_generator ['--channel=beta']
-      assert_all_ember_files
-      assert_all_ember_data_files
     end
+    assert_all_ember_files
+    assert_all_ember_data_files
   end
 
   test "with options channel=canary it should load the beta ember-data & ember files" do
     VCR.use_cassette('fetch_ember_canary') do
       run_generator ['--channel=canary']
-      assert_all_ember_files
-      assert_all_ember_data_files
     end
+    assert_all_ember_files
+    assert_all_ember_data_files
   end
 
   test "with options channel set and options --head it should raise exception ConflictingOptions" do


### PR DESCRIPTION
Default channel is `:release` (Symbol) but channel from option is `"release"` (String).
So `rails g ember:install --channel=release` couldn't fallback to beta channel
and it causes download error:

```
ERROR: Error reading the content from the channel with url
http://builds.emberjs.com/release/ember-data.js. File not found
```
