### PR TITLE
Fix tests for Handlebars 2.0

### DIFF
--- a/test/hjstemplate_test.rb
+++ b/test/hjstemplate_test.rb
@@ -102,32 +102,33 @@ class HjsTemplateTest < IntegrationTest
       template = Ember::Handlebars::Template.new template_path.to_s
       asset = app.assets.attributes_for(template_path)
 
-      assert_match /define\('appkit\/templates\/test', \['exports'\], function\(__exports__\)\{ __exports__\['default'\] = Ember\.Handlebars\.template\(function .*"test"/m, template.render(asset)
+      assert_match /define\('appkit\/templates\/test', \['exports'\], function\(__exports__\)\{ __exports__\['default'\] = Ember\.Handlebars\.template\(/m, template.render(asset)
     end
   end
 
   test "asset pipeline should serve template" do
     get "/assets/templates/test.js"
     assert_response :success
-    assert_match /Ember\.TEMPLATES\["test"\] = Ember\.Handlebars\.template\(function .*"test"/m, @response.body
+    assert_match /Ember\.TEMPLATES\["test"\] = Ember\.Handlebars\.template\(/m, @response.body
   end
 
   test "asset pipeline should serve bundled application.js" do
     get "/assets/application.js"
     assert_response :success
-    assert_match /Ember\.TEMPLATES\["test"\] = Ember\.Handlebars\.template\(function .*"test"/m, @response.body
+    assert_match /Ember\.TEMPLATES\["test"\] = Ember\.Handlebars\.template\(/m, @response.body
   end
 
   test "should unbind mustache templates" do
     get "/assets/templates/hairy.mustache"
     assert_response :success
-    assert_match /Ember\.TEMPLATES\["hairy(\.mustache)?"\] = Ember\.Handlebars\.template\(function .*unbound/m, @response.body
+    assert_match /Ember\.TEMPLATES\["hairy(\.mustache)?"\] = Ember\.Handlebars\.template\(/m, @response.body
+    assert_match /function .*unbound|"name":"unbound"/m, @response.body
   end
 
   test "ensure new lines inside the anon function are persisted" do
     get "/assets/templates/new_lines.js"
     assert_response :success
-    assert @response.body.include?("; data = data || {};\n"), @response.body.inspect
+    assert @response.body =~ /; data = data || {};\n|"data":data/, @response.body.inspect
   end
 
 end


### PR DESCRIPTION
ember-source 1.9.0 depends on Handlebars 2.0.
The precompiled code from this version is not compatible with Handlebars 1.3.0.

So I fixed test code with compatibility.
But a bit weak than previous revision...

If it is not acceptable, I'll try to switch using `if Ember::VERSION =~ /^1\.10/` or similar.
