### PR TITLE
Fix broken generator for ember-data

### DIFF
--- a/lib/generators/ember/install_generator.rb
+++ b/lib/generators/ember/install_generator.rb
@@ -83,8 +83,9 @@ module Ember
         else
           channel
         end
+
         create_file "vendor/assets/ember/#{environment}/ember-data.js" do
-          fetch url_for(channel, 'ember-data', environment), "vendor/assets/ember/#{environment}/ember-data.js"
+          fetch url_for(chan, 'ember-data', environment), "vendor/assets/ember/#{environment}/ember-data.js"
         end
       end
 


### PR DESCRIPTION
The channel fallback for ember-data doesn't work correctly.
`release -> beta` is expected but actual `release -> release`.

This cause is that the following PRs have incompatible changes:
- https://github.com/emberjs/ember-rails/pull/403
- https://github.com/emberjs/ember-rails/pull/404
