### PR TITLE
Avoid test failure for Rails 4.2.0 caused by AMS 0.9.2

### DIFF
--- a/test/dummy/config/initializers/workaround_for_ams.rb
+++ b/test/dummy/config/initializers/workaround_for_ams.rb
@@ -1,0 +1,3 @@
+# Avoid conflict ActiveModel::Serializers 0.9.2 with Rails 4.2.0: https://github.com/rails-api/active_model_serializers/pull/759
+# TODO Remove this code when it solved.
+::ActionController::Serialization.enabled = false


### PR DESCRIPTION
See for detail: https://github.com/emberjs/ember-rails/issues/408#issuecomment-66860483
