### PR TITLE
README: list default values for config.ember.variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ config files (`config/application.rb`, `config/environments/development.rb`, etc
 
 | Configuration Option                         | Description                                                                                                         |
 |----------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| `config.ember.variant`                       | Determines which Ember variant to use. Valid options: `:development`, `:production`.                                |
+| `config.ember.variant`                       | Determines which Ember variant to use. Valid options: `:development`, `:production`. Defaults to `:production` in production, and `:development` everywhere else.                               |
 | `config.ember.app_name`                      | Specificies a default application name for all generators.                                                          |
 | `config.ember.ember_path`                    | Specifies a default custom root path for all generators.                                                            |
 | `config.handlebars.precompile`               | Enables or disables precompilation. Default value: `true`.                                                          |


### PR DESCRIPTION
From the README and various guides I've been reading, it wasn't clear whether `config.ember.variant` was something that needed to be set. Some guides say to specify it in every `config/environments/*` file, while others skip over the config option entirely.

Then I looked it up in the [source code](https://github.com/emberjs/ember-rails/blob/36067b4c5c8e81edc2f5b43cd7bf0459ca258dfd/lib/ember_rails.rb#L24). Figured it'd be good to clarify this in the README :cat: 
