### PR TITLE
Remove workaround for ActiveModelSerializers gem

### DIFF
--- a/test/dummy/config/initializers/workaround_for_ams.rb
+++ b/test/dummy/config/initializers/workaround_for_ams.rb
@@ -1,3 +1,0 @@
-# Avoid conflict ActiveModel::Serializers 0.9.2 with Rails 4.2.0: https://github.com/rails-api/active_model_serializers/pull/759
-# TODO Remove this code when it solved.
-::ActionController::Serialization.enabled = false


### PR DESCRIPTION
This workaround is no longer needed in 0.9.3.