### PR TITLE
Setup bundled assets in ember-source & ember-data-source

### DIFF
--- a/lib/ember_rails.rb
+++ b/lib/ember_rails.rb
@@ -20,7 +20,15 @@ module Ember
         require "generators/ember/resource_override"
       end
 
-      initializer "ember_rails.setup_vendor", :after => "ember_rails.setup", :group => :all do |app|
+      initializer "ember_rails.setup_vendor_on_locale", :after => "ember_rails.setup", :group => :all do |app|
+        variant = app.config.ember.variant || (::Rails.env.production? ? :production : :development)
+
+        # Allow a local variant override
+        ember_path = app.root.join("vendor/assets/ember/#{variant}")
+        app.assets.prepend_path(ember_path.to_s) if ember_path.exist?
+      end
+
+      initializer "ember_rails.copy_vendor_to_local", :after => "ember_rails.setup", :group => :all do |app|
         variant = app.config.ember.variant || (::Rails.env.production? ? :production : :development)
 
         # Copy over the desired ember and ember-data bundled in
@@ -38,20 +46,13 @@ module Ember
         ember_data_ext = variant == :production ? ".prod.js" : ".js"
         FileUtils.cp(::Ember::Data::Source.bundled_path_for("ember-data#{ember_data_ext}"), tmp_path.join("ember-data.js"))
 
-        # Copy ember-data source map to tmp folder.
-        if File.exist?(::Ember::Data::Source.bundled_path_for("ember-data.js.map")) # Source maps are present in ember-data-source gem, starting from version 1.0.0-beta.14.1
-          FileUtils.cp(::Ember::Data::Source.bundled_path_for("ember-data.js.map"), tmp_path.join("ember-data.js.map"))
-        end
-        
         app.assets.append_path(tmp_path)
+      end
 
-        # Make the handlebars.js and handlebars.runtime.js bundled
-        # in handlebars-source available.
+      initializer "ember_rails.setup_vendor", :after => "ember_rails.copy_vendor_to_local", :group => :all do |app|
+        app.assets.append_path(::Ember::Source.bundled_path_for(nil))
+        app.assets.append_path(::Ember::Data::Source.bundled_path_for(nil))
         app.assets.append_path(File.expand_path('../', ::Handlebars::Source.bundled_path))
-
-        # Allow a local variant override
-        ember_path = app.root.join("vendor/assets/ember/#{variant}")
-        app.assets.prepend_path(ember_path.to_s) if ember_path.exist?
       end
 
       initializer "ember_rails.es5_default", :group => :all do |app|


### PR DESCRIPTION
The bundled assets (like a `ember-runtime.js` or `ember-template-compiler.js` etc) may be needed from some projects without handlebars precompilation.
To reference these files, bundles assets should be on asset paths.