### PR TITLE
Remove handlebars dependency

### DIFF
--- a/ember-rails.gemspec
+++ b/ember-rails.gemspec
@@ -19,16 +19,16 @@ Gem::Specification.new do |s|
 
   s.add_dependency "jquery-rails", ">= 1.0.17"
   s.add_dependency "ember-source", ">= 1.1.0"
-  s.add_dependency "handlebars-source", "> 1.0.0", "< 3"
   s.add_dependency "ember-data-source", '>= 1.0.0.beta.5'
 
   s.add_development_dependency "bundler", [">= 1.2.2"]
   s.add_development_dependency "appraisal", ">= 1.0.0"
   s.add_development_dependency "tzinfo"
-
-  s.add_development_dependency "sprockets-rails"
   s.add_development_dependency "vcr"
   s.add_development_dependency "webmock", "< 1.14.0"
+
+  s.add_development_dependency "sprockets-rails"
+  s.add_development_dependency "handlebars-source", "> 1.0.0", "< 3"
 
   s.files = %w(README.md LICENSE) + Dir["lib/**/*", "vendor/**/*"]
 

--- a/lib/ember_rails.rb
+++ b/lib/ember_rails.rb
@@ -4,6 +4,13 @@ require 'ember/data/source'
 require 'ember/rails/version'
 require 'ember/rails/engine'
 
+# Use handlebars if it possible. Because it is an optional feature.
+begin
+  require 'handlebars/source'
+rescue LoadError => e
+  raise e unless e.message == 'cannot load such file -- handlebars/source'
+end
+
 module Ember
   module Rails
     class Railtie < ::Rails::Railtie

--- a/lib/ember_rails.rb
+++ b/lib/ember_rails.rb
@@ -3,7 +3,6 @@ require 'ember/source'
 require 'ember/data/source'
 require 'ember/rails/version'
 require 'ember/rails/engine'
-require 'handlebars/source'
 
 module Ember
   module Rails
@@ -52,7 +51,7 @@ module Ember
       initializer "ember_rails.setup_vendor", :after => "ember_rails.copy_vendor_to_local", :group => :all do |app|
         app.assets.append_path(::Ember::Source.bundled_path_for(nil))
         app.assets.append_path(::Ember::Data::Source.bundled_path_for(nil))
-        app.assets.append_path(File.expand_path('../', ::Handlebars::Source.bundled_path))
+        app.assets.append_path(File.expand_path('../', ::Handlebars::Source.bundled_path)) if defined?(::Handlebars::Source)
       end
 
       initializer "ember_rails.es5_default", :group => :all do |app|

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -6,6 +6,7 @@ require 'sprockets/railtie'
 
 Bundler.require
 require "ember-rails"
+require "handlebars/source" # Enable optional features related handlebars.
 
 module Dummy
   class Application < Rails::Application

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,5 @@ rescue LoadError
 end
 
 require 'active_support/core_ext/kernel/reporting'
-require 'pathname'
 
 Rails.backtrace_cleaner.remove_silencers!


### PR DESCRIPTION
**Please do not merge this**

The following features became optional.
* handlebars precompilation
* Appending handlebars to sprockets path

## TODO

* [x] Make handlebars features into optional
* [x] Use released barber including https://github.com/tchak/barber/pull/35 (Otherwise, handlebars-source 3.0 is used and precompilation is broken)