### PR TITLE
Update generator using `Ember.Controller` instead of `Ember.ObjectController`

### DIFF
--- a/lib/generators/ember/controller_generator.rb
+++ b/lib/generators/ember/controller_generator.rb
@@ -12,7 +12,7 @@ module Ember
       class_option :javascript_engine, :desc => "Engine for JavaScripts"
       class_option :array, :type => :boolean, :default => false, :desc => "Create an Ember.ArrayController to represent multiple objects"
       class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "Custom ember app path"
-      class_option :object, :type => :boolean, :default => false, :desc => "Create an Ember.ObjectController to represent a single object"
+      class_option :object, :type => :boolean, :default => false, :desc => "Create an Ember.Controller to represent a single object"
       class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
 
 

--- a/lib/generators/ember/resource_generator.rb
+++ b/lib/generators/ember/resource_generator.rb
@@ -12,7 +12,7 @@ module Ember
       class_option :javascript_engine, :desc => "Engine for JavaScripts"
       class_option :skip_route, :type => :boolean, :default => false, :desc => "Don't create route"
       class_option :array, :type => :boolean, :default => false, :desc => "Create an Ember.ArrayController to represent multiple objects"
-      class_option :object, :type => :boolean, :default => false, :desc => "Create an Ember.ObjectController to represent a single object"
+      class_option :object, :type => :boolean, :default => false, :desc => "Create an Ember.Controller to represent a single object"
       class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
 
 

--- a/lib/generators/templates/object_controller.js
+++ b/lib/generators/templates/object_controller.js
@@ -1,5 +1,5 @@
 // for more details see: http://emberjs.com/guides/controllers/
 
-<%= application_name.camelize %>.<%= class_name %>Controller = Ember.ObjectController.extend({
+<%= application_name.camelize %>.<%= class_name %>Controller = Ember.Controller.extend({
 
 });

--- a/lib/generators/templates/object_controller.js.coffee
+++ b/lib/generators/templates/object_controller.js.coffee
@@ -1,5 +1,5 @@
 # for more details see: http://emberjs.com/guides/controllers/
 
-<%= application_name.camelize %>.<%= class_name %>Controller = Ember.ObjectController.extend({
+<%= application_name.camelize %>.<%= class_name %>Controller = Ember.Controller.extend({
 
 })

--- a/lib/generators/templates/object_controller.js.em
+++ b/lib/generators/templates/object_controller.js.em
@@ -1,3 +1,3 @@
 # for more details see: http://emberjs.com/guides/controllers/
 
-class <%= application_name.camelize %>.<%= class_name %>Controller extends Ember.ObjectController
+class <%= application_name.camelize %>.<%= class_name %>Controller extends Ember.Controller


### PR DESCRIPTION
`Ember.ObjectController` is deprecated since Ember.js 1.10.0.