### PR TITLE
Locks active_model_support version at 0.9.0

### DIFF
--- a/ember-rails.gemspec
+++ b/ember-rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.add_dependency "railties", [">= 3.1"]
-  s.add_dependency "active_model_serializers"
+  s.add_dependency "active_model_serializers", '0.9.0'
 
   s.add_dependency "jquery-rails", ">= 1.0.17"
   s.add_dependency "ember-source", ">= 1.1.0"


### PR DESCRIPTION
To fix this error, I locked `active_model_support` at 0.9.0. Regardles of whether this gets merged, it would be great to fix this issue. Ruby/Rails versions included in the stacktrace.

```
/Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/draper-1.4.0/lib/draper/railtie.rb:48:in `block (2 levels) in <class:Railtie>': uninitialized constant ActiveModel::ArraySerializerSupport (NameError)
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.0/lib/active_support/lazy_load_hooks.rb:38:in `instance_eval'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.0/lib/active_support/lazy_load_hooks.rb:38:in `execute_hook'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.0/lib/active_support/lazy_load_hooks.rb:28:in `block in on_load'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.0/lib/active_support/lazy_load_hooks.rb:27:in `each'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/activesupport-4.2.0/lib/active_support/lazy_load_hooks.rb:27:in `on_load'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/draper-1.4.0/lib/draper/railtie.rb:47:in `block in <class:Railtie>'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/railties-4.2.0/lib/rails/initializable.rb:30:in `instance_exec'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/railties-4.2.0/lib/rails/initializable.rb:30:in `run'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/railties-4.2.0/lib/rails/initializable.rb:55:in `block in run_initializers'
	from /Users/bwheeler/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:226:in `block in tsort_each'
	from /Users/bwheeler/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:348:in `block (2 levels) in each_strongly_connected_component'
	from /Users/bwheeler/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:429:in `each_strongly_connected_component_from'
	from /Users/bwheeler/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:347:in `block in each_strongly_connected_component'
	from /Users/bwheeler/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:345:in `each'
	from /Users/bwheeler/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:345:in `call'
	from /Users/bwheeler/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:345:in `each_strongly_connected_component'
	from /Users/bwheeler/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:224:in `tsort_each'
	from /Users/bwheeler/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tsort.rb:203:in `tsort_each'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/railties-4.2.0/lib/rails/initializable.rb:54:in `run_initializers'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/railties-4.2.0/lib/rails/application.rb:352:in `initialize!'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/railties-4.2.0/lib/rails/railtie.rb:194:in `public_send'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/railties-4.2.0/lib/rails/railtie.rb:194:in `method_missing'
	from /Users/bwheeler/Workspace/facelift/config/environment.rb:5:in `<top (required)>'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/bundler/gems/skylight-ruby-0988a45b756e/lib/skylight/probes.rb:81:in `require'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/bundler/gems/skylight-ruby-0988a45b756e/lib/skylight/probes.rb:81:in `require'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/spring-1.3.6/lib/spring/application.rb:92:in `preload'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/spring-1.3.6/lib/spring/application.rb:143:in `serve'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/spring-1.3.6/lib/spring/application.rb:131:in `block in run'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/spring-1.3.6/lib/spring/application.rb:125:in `loop'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/spring-1.3.6/lib/spring/application.rb:125:in `run'
	from /Users/bwheeler/.rvm/gems/ruby-2.2.1/gems/spring-1.3.6/lib/spring/application/boot.rb:18:in `<top (required)>'
	from /Users/bwheeler/.rvm/rubies/ruby-2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /Users/bwheeler/.rvm/rubies/ruby-2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'

```