### PR TITLE
Drop old ember

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ rvm:
   - 2.1
   - 2.2
   - jruby-19mode
-before_script: "bundle exec appraisal install"
+before_script:
+  - gem install bundler # To use bundler 1.10
+  - "bundle exec appraisal install"
 script: "bundle exec rake appraisal test"

--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,6 @@
-appraise 'rails32_ember_11' do
+appraise 'rails32_ember_18' do
   gem 'rails', '~> 3.2'
-  gem 'ember-source', '~> 1.1.0'
+  gem 'ember-source', '~> 1.8.0'
   gem 'handlebars-source', '~> 1.0.0'
 end
 
@@ -12,12 +12,12 @@ end
 
 appraise 'rails32_ember_latest' do
   gem 'rails', '~> 3.2'
-  gem 'ember-source', '~> 1.11.0'
+  gem 'ember-source', '~> 1.13.0'
 end
 
-appraise 'rails4_ember_11' do
+appraise 'rails4_ember_18' do
   gem 'rails', '~> 4.0.0'
-  gem 'ember-source', '~> 1.1.0'
+  gem 'ember-source', '~> 1.8.0'
   gem 'handlebars-source', '~> 1.0.0'
 end
 
@@ -29,12 +29,12 @@ end
 
 appraise 'rails4_ember_latest' do
   gem 'rails', '~> 4.0.0'
-  gem 'ember-source', '~> 1.11.0'
+  gem 'ember-source', '~> 1.13.0'
 end
 
-appraise 'rails41_ember_11' do
+appraise 'rails41_ember_18' do
   gem 'rails', '~> 4.1.0'
-  gem 'ember-source', '~> 1.1.0'
+  gem 'ember-source', '~> 1.8.0'
   gem 'handlebars-source', '~> 1.0.0'
 end
 
@@ -46,12 +46,12 @@ end
 
 appraise 'rails41_ember_latest' do
   gem 'rails', '~> 4.1.0'
-  gem 'ember-source', '~> 1.11.0'
+  gem 'ember-source', '~> 1.13.0'
 end
 
-appraise 'rails42_ember_11' do
+appraise 'rails42_ember_18' do
   gem 'rails', '~> 4.2.0'
-  gem 'ember-source', '~> 1.1.0'
+  gem 'ember-source', '~> 1.8.0'
   gem 'handlebars-source', '~> 1.0.0'
 end
 
@@ -63,11 +63,11 @@ end
 
 appraise 'rails42_ember_latest' do
   gem 'rails', '~> 4.2.0'
-  gem 'ember-source', '~> 1.11.0'
+  gem 'ember-source', '~> 1.13.0'
 end
 
 appraise 'sprockets-3' do
   gem 'rails', '~> 4.2.0'
-  gem 'ember-source', '~> 1.11.0'
-  gem 'sprockets', '~> 3.0.0.beta.10'
+  gem 'ember-source', '~> 1.13.0'
+  gem 'sprockets', '~> 3.0.0'
 end

--- a/ember-rails.gemspec
+++ b/ember-rails.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.add_dependency "active_model_serializers"
 
   s.add_dependency "jquery-rails", ">= 1.0.17"
-  s.add_dependency "ember-source", ">= 1.1.0"
-  s.add_dependency "ember-data-source", '>= 1.0.0.beta.5'
+  s.add_dependency "ember-source", ">= 1.8.0"
+  s.add_dependency "ember-data-source", '>= 1.13.0'
   s.add_dependency "ember-handlebars-template", ">= 0.1.1", "< 1.0"
 
   s.add_development_dependency "bundler", [">= 1.2.2"]

--- a/gemfiles/rails32_ember_18.gemfile
+++ b/gemfiles/rails32_ember_18.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 4.2.0"
-gem "ember-source", "~> 1.1.0"
+gem "rails", "~> 3.2"
+gem "ember-source", "~> 1.8.0"
 gem "handlebars-source", "~> 1.0.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails32_ember_latest.gemfile
+++ b/gemfiles/rails32_ember_latest.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 3.2"
-gem "ember-source", "~> 1.11.0"
+gem "ember-source", "~> 1.13.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails41_ember_18.gemfile
+++ b/gemfiles/rails41_ember_18.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.1.0"
-gem "ember-source", "~> 1.1.0"
+gem "ember-source", "~> 1.8.0"
 gem "handlebars-source", "~> 1.0.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails41_ember_latest.gemfile
+++ b/gemfiles/rails41_ember_latest.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.1.0"
-gem "ember-source", "~> 1.11.0"
+gem "ember-source", "~> 1.13.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails42_ember_18.gemfile
+++ b/gemfiles/rails42_ember_18.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 3.2"
-gem "ember-source", "~> 1.1.0"
+gem "rails", "~> 4.2.0"
+gem "ember-source", "~> 1.8.0"
 gem "handlebars-source", "~> 1.0.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails42_ember_latest.gemfile
+++ b/gemfiles/rails42_ember_latest.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
-gem "ember-source", "~> 1.11.0"
+gem "ember-source", "~> 1.13.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails4_ember_18.gemfile
+++ b/gemfiles/rails4_ember_18.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.0.0"
-gem "ember-source", "~> 1.1.0"
+gem "ember-source", "~> 1.8.0"
 gem "handlebars-source", "~> 1.0.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails4_ember_latest.gemfile
+++ b/gemfiles/rails4_ember_latest.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.0.0"
-gem "ember-source", "~> 1.11.0"
+gem "ember-source", "~> 1.13.0"
 
 gemspec :path => "../"

--- a/gemfiles/sprockets_3.gemfile
+++ b/gemfiles/sprockets_3.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
-gem "ember-source", "~> 1.11.0"
-gem "sprockets", "~> 3.0.0.beta.10"
+gem "ember-source", "~> 1.13.0"
+gem "sprockets", "~> 3.0.0"
 
 gemspec :path => "../"


### PR DESCRIPTION
We want to follow Ember Data's released version.
This is an advance preparation of https://github.com/emberjs/ember-rails/pull/478.