### PR TITLE
Use `Ember::Handlebars::Template.setup`

### DIFF
--- a/lib/ember/rails/engine.rb
+++ b/lib/ember/rails/engine.rb
@@ -17,9 +17,8 @@ module Ember
 
       config.before_initialize do |app|
         Sprockets::Engines #force autoloading
-        Sprockets.register_engine '.handlebars', Ember::Handlebars::Template
-        Sprockets.register_engine '.hbs', Ember::Handlebars::Template
-        Sprockets.register_engine '.hjs', Ember::Handlebars::Template
+
+        Ember::Handlebars::Template.setup Sprockets
       end
     end
   end


### PR DESCRIPTION
This is the same fix as https://github.com/emberjs/ember-rails/pull/489 for old ember-source supported version.
