### PR TITLE
Use the 'prod' variant when downloading ember

### DIFF
--- a/lib/generators/ember/install_generator.rb
+++ b/lib/generators/ember/install_generator.rb
@@ -101,7 +101,7 @@ module Ember
 
         case environment
         when :production
-          "#{base}.min.js"
+          "#{base}.prod.js"
         when :development
           if resource_exist?("#{base}.debug.js")
             "#{base}.debug.js" # Ember.js 1.10.0.beta.1 or later


### PR DESCRIPTION
Use the 'prod' variant when downloading ember from the CDN for production version, I'd hope everyone is handling minification themselves