### PR TITLE
Update sprockets-rails version to 3.0.0 for test

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -71,5 +71,5 @@ end
 appraise 'sprockets-rails-3' do
   gem 'rails', '~> 4.2.0'
   gem 'ember-source', '~> 1.13.0'
-  gem 'sprockets-rails', '~> 3.0.0.beta.2'
+  gem 'sprockets-rails', '~> 3.0.0'
 end

--- a/gemfiles/sprockets_rails_3.gemfile
+++ b/gemfiles/sprockets_rails_3.gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
 gem "ember-source", "~> 1.13.0"
-gem "sprockets-rails", "~> 3.0.0.beta.2"
+gem "sprockets-rails", "~> 3.0.0"
 
 gemspec :path => "../"


### PR DESCRIPTION
sprockets-rails 3.0.0 is released now.
https://github.com/rails/sprockets-rails/tree/v3.0.0