### PR TITLE
Fix environment.coffee/em generator typo

### DIFF
--- a/lib/generators/templates/environment.coffee
+++ b/lib/generators/templates/environment.coffee
@@ -1,4 +1,4 @@
-wondow.EmberENV = {
+window.EmberENV = {
   # FEATURES: {},
   # EXTEND_PROTOTYPES: {
   #    Function: false,

--- a/lib/generators/templates/environment.em
+++ b/lib/generators/templates/environment.em
@@ -1,4 +1,4 @@
-wondow.EmberENV = {
+window.EmberENV = {
   # FEATURES: {},
   # EXTEND_PROTOTYPES: {
   #    Function: false,


### PR DESCRIPTION
There is a typo in environment.coffee and environment.em files when using generators.