### PR TITLE
Allow ember-es6_template 0.5.x

### DIFF
--- a/ember-rails.gemspec
+++ b/ember-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ember-data-source", '>= 1.13.0'
   s.add_dependency "active-model-adapter-source", ">= 1.13.0"
   s.add_dependency "ember-handlebars-template", ">= 0.1.1", "< 1.0"
-  s.add_dependency "ember-es6_template", "~> 0.4.0"
+  s.add_dependency "ember-es6_template", ">= 0.4.0", "< 0.6"
   s.add_dependency "ember-cli-assets", "~> 0.0.1"
 
   s.add_development_dependency "bundler", [">= 1.2.2"]


### PR DESCRIPTION
It allows sprockets 4.0.0.beta.

All changes of `ember-es6_template` are here:
https://github.com/tricknotes/ember-es6_template/compare/v0.4.3...v0.5.1
