### PR TITLE
Add support for Sprockets 4

### DIFF
--- a/ember-rails.gemspec
+++ b/ember-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ember-data-source", '>= 1.13.0'
   s.add_dependency "active-model-adapter-source", ">= 1.13.0"
   s.add_dependency "ember-handlebars-template", ">= 0.1.1", "< 1.0"
-  s.add_dependency "ember-es6_template", "~> 0.4.0"
+  s.add_dependency "ember-es6_template", "~> 0.5.0"
   s.add_dependency "ember-cli-assets", "~> 0.0.1"
 
   s.add_development_dependency "bundler", [">= 1.2.2"]

--- a/lib/ember/rails/engine.rb
+++ b/lib/ember/rails/engine.rb
@@ -19,7 +19,9 @@ module Ember
       end
 
       config.before_initialize do |app|
-        Sprockets::Engines #force autoloading
+        if Sprockets::VERSION =~ /\A[0-3]\./
+          Sprockets::Engines #force autoloading
+        end
       end
 
       config.before_initialize do |app|

--- a/lib/ember_rails.rb
+++ b/lib/ember_rails.rb
@@ -100,7 +100,11 @@ module Ember
 
       initializer "ember_rails.setup_ember_template_compiler", :after => "ember_rails.setup_vendor", :group => :all do |app|
         configure_assets app do |env|
-          Ember::Handlebars::Template.setup_ember_template_compiler(env.resolve('ember-template-compiler.js'))
+          ember_template_compiler, _ = env.resolve('ember-template-compiler.js')
+          if env.valid_asset_uri?(ember_template_compiler)
+            ember_template_compiler, _ = env.parse_asset_uri(ember_template_compiler)
+          end
+          Ember::Handlebars::Template.setup_ember_template_compiler(ember_template_compiler)
         end
       end
 

--- a/test/dummy/config/boot.rb
+++ b/test/dummy/config/boot.rb
@@ -2,7 +2,7 @@ require 'rubygems'
 gemfile = File.expand_path('../../../../Gemfile', __FILE__)
 
 if File.exist?(gemfile)
-  ENV['BUNDLE_GEMFILE'] = gemfile
+  ENV['BUNDLE_GEMFILE'] ||= gemfile
   require 'bundler'
   Bundler.setup
 end


### PR DESCRIPTION
There was very little required by this gem to work with sprockets 4. It
is primarily just upgrading the versions of dependencies, and removing
the reliance on one Sprockets 2 API which had a legacy shim in Sprockets
3 that has been removed.

After these changes, Sprockets 2, 3, and 4 should all still be
supported.