### PR TITLE
Fix tests for latest ember

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ rvm:
   - jruby-9.1.0.0
 cache:
   - bundler
-before_script:
-  - gem install bundler # To use bundler 1.10 or later
+before_install:
+  - gem update bundler # To use bundler 1.10 or later
 gemfile:
   - gemfiles/rails32_ember_113.gemfile
   - gemfiles/rails40_ember_113.gemfile

--- a/test/hjstemplate_test.rb
+++ b/test/hjstemplate_test.rb
@@ -28,7 +28,7 @@ class HjsTemplateTest < IntegrationTest
     get "/assets/templates/hairy.js"
     assert_response :success
     assert_match %r{Ember\.TEMPLATES\["hairy(\.mustache)?"\] = Ember\.(?:Handlebars|HTMLBars)\.template\(}m, @response.body
-    assert_match %r{function .*unbound|"name":"unbound"}m, @response.body
+    assert_match %r{function .*unbound|"name":"unbound"|\[\\"unbound\\"\]}m, @response.body
   end
 
   test "ensure new lines inside the anon function are persisted" do

--- a/test/precompile_test.rb
+++ b/test/precompile_test.rb
@@ -28,7 +28,7 @@ class PrecompileTest < TestCase
 
     contents = File.read(application_js_path)
 
-    assert_match %r{Ember\.VERSION}, contents, 'application.js should contain Ember.VERSION'
+    assert_match %r{Ember\.VERSION|_emberVersion\.default}, contents, 'application.js should contain Ember.VERSION'
     assert_match %r{Handlebars\.VERSION|COMPILER_REVISION}, contents, 'applciation.js should contain Handlebars.VERSION'
   end
 


### PR DESCRIPTION
Ember.js 2.10 has some internal changes.
This PR fixes failing tests depending internal API.