### PR TITLE
Remove type mismatched default value from generator options

### DIFF
--- a/lib/generators/ember/adapter_generator.rb
+++ b/lib/generators/ember/adapter_generator.rb
@@ -8,9 +8,9 @@ module Ember
       source_root File.expand_path("../../templates", __FILE__)
 
       desc "Creates a new Ember.js adapter"
-      class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "Custom ember app path"
+      class_option :ember_path, :type => :string, :aliases => "-d", :desc => "Custom ember app path"
       class_option :javascript_engine, :desc => "Engine for JavaScripts"
-      class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
+      class_option :app_name, :type => :string, :aliases => "-n", :desc => "Custom ember app name"
 
       def create_adapter_files
         file_path = File.join(ember_path, 'adapters', class_path, "#{file_name}.#{engine_extension}")

--- a/lib/generators/ember/bootstrap_generator.rb
+++ b/lib/generators/ember/bootstrap_generator.rb
@@ -9,10 +9,10 @@ module Ember
 
       desc "Creates a default Ember.js folder layout in app/assets/javascripts"
 
-      class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "Custom ember app path"
+      class_option :ember_path, :type => :string, :aliases => "-d", :desc => "Custom ember app path"
       class_option :skip_git, :type => :boolean, :aliases => "-g", :default => false, :desc => "Skip Git keeps"
       class_option :javascript_engine, :desc => "Engine for JavaScripts (js for JavaScript, coffee for CoffeeScript, etc)"
-      class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
+      class_option :app_name, :type => :string, :aliases => "-n", :desc => "Custom ember app name"
 
       def inject_ember
         begin

--- a/lib/generators/ember/component_generator.rb
+++ b/lib/generators/ember/component_generator.rb
@@ -10,8 +10,8 @@ module Ember
       desc "Creates a new Ember.js component and component template\nCustom Ember Components require at least two descriptive names separated by a dash. Use CamelCase or dash-case to name your component.\n\nExample,\n\trails generate ember:component PostChart [options]\n\trails generate ember:component post-chart [options]"
 
       class_option :javascript_engine, :desc => "Engine for JavaScripts"
-      class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "Custom ember app path"
-      class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
+      class_option :ember_path, :type => :string, :aliases => "-d", :desc => "Custom ember app path"
+      class_option :app_name, :type => :string, :aliases => "-n", :desc => "Custom ember app name"
 
       def create_component_files
         dashed_file_name = file_name.dasherize

--- a/lib/generators/ember/controller_generator.rb
+++ b/lib/generators/ember/controller_generator.rb
@@ -11,9 +11,9 @@ module Ember
 
       class_option :javascript_engine, :desc => "Engine for JavaScripts"
       class_option :array, :type => :boolean, :default => false, :desc => "Create an Ember.ArrayController to represent multiple objects"
-      class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "Custom ember app path"
+      class_option :ember_path, :type => :string, :aliases => "-d", :desc => "Custom ember app path"
       class_option :object, :type => :boolean, :default => false, :desc => "Create an Ember.Controller to represent a single object"
-      class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
+      class_option :app_name, :type => :string, :aliases => "-n", :desc => "Custom ember app name"
 
 
       def create_controller_files

--- a/lib/generators/ember/initializer_generator.rb
+++ b/lib/generators/ember/initializer_generator.rb
@@ -10,8 +10,8 @@ module Ember
       desc "Creates a new Ember.js initializer"
 
       class_option :javascript_engine, :desc => "Engine for JavaScripts"
-      class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "Custom ember app path"
-      class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
+      class_option :ember_path, :type => :string, :aliases => "-d", :desc => "Custom ember app path"
+      class_option :app_name, :type => :string, :aliases => "-n", :desc => "Custom ember app name"
 
       def create_initializer_files
         file_path = File.join(ember_path, 'initializers', class_path, "#{file_name.dasherize}.#{engine_extension}")

--- a/lib/generators/ember/instance_initializer_generator.rb
+++ b/lib/generators/ember/instance_initializer_generator.rb
@@ -10,8 +10,8 @@ module Ember
       desc "Creates a new Ember.js instance initializer"
 
       class_option :javascript_engine, :desc => "Engine for JavaScripts"
-      class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "Custom ember app path"
-      class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
+      class_option :ember_path, :type => :string, :aliases => "-d", :desc => "Custom ember app path"
+      class_option :app_name, :type => :string, :aliases => "-n", :desc => "Custom ember app name"
 
       def create_instance_initializer_files
         file_path = File.join(ember_path, 'instance-initializers', class_path, "#{file_name.dasherize}.#{engine_extension}")

--- a/lib/generators/ember/model_generator.rb
+++ b/lib/generators/ember/model_generator.rb
@@ -9,8 +9,8 @@ module Ember
       desc "creates a new ember.js model"
       argument :attributes, :type => :array, :default => [], :banner => "field[:type] field[:type] ..."
       class_option :javascript_engine, :desc => "engine for javascripts"
-      class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "custom ember app path"
-      class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
+      class_option :ember_path, :type => :string, :aliases => "-d", :desc => "custom ember app path"
+      class_option :app_name, :type => :string, :aliases => "-n", :desc => "Custom ember app name"
 
       def create_model_files
         file_path = File.join(ember_path, 'models', class_path, "#{file_name.dasherize}.#{engine_extension}")

--- a/lib/generators/ember/resource_generator.rb
+++ b/lib/generators/ember/resource_generator.rb
@@ -13,7 +13,7 @@ module Ember
       class_option :skip_route, :type => :boolean, :default => false, :desc => "Don't create route"
       class_option :array, :type => :boolean, :default => false, :desc => "Create an Ember.ArrayController to represent multiple objects"
       class_option :object, :type => :boolean, :default => false, :desc => "Create an Ember.Controller to represent a single object"
-      class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
+      class_option :app_name, :type => :string, :aliases => "-n", :desc => "Custom ember app name"
 
 
       def create_resource_files

--- a/lib/generators/ember/resource_override.rb
+++ b/lib/generators/ember/resource_override.rb
@@ -8,9 +8,9 @@ module Rails
     ResourceGenerator.class_eval do
 
       class_option :javascript_engine, :desc => "Engine for JavaScripts"
-      class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "Custom ember app path"
+      class_option :ember_path, :type => :string, :aliases => "-d", :desc => "Custom ember app path"
       class_option :with_template, :type => :boolean, :default => false, :desc => "Create template for this view"
-      class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
+      class_option :app_name, :type => :string, :aliases => "-n", :desc => "Custom ember app name"
 
       def add_ember
         say_status :invoke, "ember:model", :white

--- a/lib/generators/ember/route_generator.rb
+++ b/lib/generators/ember/route_generator.rb
@@ -8,9 +8,9 @@ module Ember
       source_root File.expand_path("../../templates", __FILE__)
 
       desc "Creates a new Ember.js route"
-      class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "Custom ember app path"
+      class_option :ember_path, :type => :string, :aliases => "-d", :desc => "Custom ember app path"
       class_option :javascript_engine, :desc => "Engine for JavaScripts"
-      class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
+      class_option :app_name, :type => :string, :aliases => "-n", :desc => "Custom ember app name"
 
       def create_route_files
         file_path = File.join(ember_path, 'routes', class_path, "#{file_name.dasherize}.#{engine_extension}")

--- a/lib/generators/ember/service_generator.rb
+++ b/lib/generators/ember/service_generator.rb
@@ -10,8 +10,8 @@ module Ember
       desc "Creates a new Ember.js service"
 
       class_option :javascript_engine, :desc => "Engine for JavaScripts"
-      class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "Custom ember app path"
-      class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
+      class_option :ember_path, :type => :string, :aliases => "-d", :desc => "Custom ember app path"
+      class_option :app_name, :type => :string, :aliases => "-n", :desc => "Custom ember app name"
 
       def create_service_files
         file_path = File.join(ember_path, 'services', class_path, "#{file_name.dasherize}.#{engine_extension}")

--- a/lib/generators/ember/template_generator.rb
+++ b/lib/generators/ember/template_generator.rb
@@ -9,7 +9,7 @@ module Ember
 
       desc "Creates a new Ember.js template"
       class_option :javascript_engine, :desc => "Engine for JavaScripts"
-      class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "Custom ember app path"
+      class_option :ember_path, :type => :string, :aliases => "-d", :desc => "Custom ember app path"
 
       def create_template_files
         file_path = File.join(ember_path, 'templates', class_path, "#{file_name.dasherize}.hbs")

--- a/lib/generators/ember/view_generator.rb
+++ b/lib/generators/ember/view_generator.rb
@@ -9,9 +9,9 @@ module Ember
 
       desc "Creates a new Ember.js view and associated Handlebars template"
       class_option :javascript_engine, :desc => "Engine for JavaScripts"
-      class_option :ember_path, :type => :string, :aliases => "-d", :default => false, :desc => "Custom ember app path"
+      class_option :ember_path, :type => :string, :aliases => "-d", :desc => "Custom ember app path"
       class_option :with_template, :type => :boolean, :default => false, :desc => "Create template for this view"
-      class_option :app_name, :type => :string, :aliases => "-n", :default => false, :desc => "Custom ember app name"
+      class_option :app_name, :type => :string, :aliases => "-n", :desc => "Custom ember app name"
 
       def create_view_files
         file_path = File.join(ember_path, 'views', class_path, "#{file_name.dasherize}.#{engine_extension}")


### PR DESCRIPTION
Since thor@0.19.3, the warning message is shown for default type
mismatch.
ref: https://github.com/erikhuda/thor/commit/605897b5a02f10a4687237667cafa8dda6ae2016

We expect these options to be `nil` by default.