### PR TITLE
Update supported Rails version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ember-rails  [![Build Status](https://secure.travis-ci.org/emberjs/ember-rails.svg?branch=master)](http://travis-ci.org/emberjs/ember-rails) [![Dependency Status](https://gemnasium.com/emberjs/ember-rails.svg)](https://gemnasium.com/emberjs/ember-rails) [![Code Climate](https://codeclimate.com/github/emberjs/ember-rails/badges/gpa.svg)](https://codeclimate.com/github/emberjs/ember-rails)
 
-ember-rails makes developing an [Ember.JS](http://emberjs.com/) application much easier in Rails 3.1+.
+ember-rails makes developing an [Ember.JS](http://emberjs.com/) application much easier in Rails 4.2+.
 
 The following functionalities are included in this gem:
 - Pre-compiling of your handlebars templates when building your asset pipeline.

--- a/ember-rails.gemspec
+++ b/ember-rails.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Keith Pitt", "Rob Monie", "Joao Carlos", "Paul Chavard"]
   s.email       = ["me@keithpitt.com", "paul@chavard.net"]
   s.homepage    = "https://github.com/emberjs/ember-rails"
-  s.summary     = "Ember for Rails 3.1+"
+  s.summary     = "Ember for Rails 4.2+"
   s.license     = "MIT"
 
   s.add_dependency "railties", [">= 4.2"]


### PR DESCRIPTION
Since https://github.com/emberjs/ember-rails/pull/540, ember-rails supports Rails 4.2+.

Close https://github.com/emberjs/ember-rails/issues/542