### PR TITLE
Fix assert_match error of "should unbind mustache templates" in HjsTemplateTest

### DIFF
--- a/test/hjstemplate_test.rb
+++ b/test/hjstemplate_test.rb
@@ -28,7 +28,7 @@ class HjsTemplateTest < IntegrationTest
     get "/assets/templates/hairy.js"
     assert_response :success
     assert_match %r{Ember\.TEMPLATES\["hairy(\.mustache)?"\] = Ember\.(?:Handlebars|HTMLBars)\.template\(}m, @response.body
-    assert_match %r{function .*unbound|"name":"unbound"|\[\\"unbound\\"\]}m, @response.body
+    assert_match %r{.*unbound|"name":"unbound"|\[\\"unbound\\"\]}m, @response.body
   end
 
   test "ensure new lines inside the anon function are persisted" do


### PR DESCRIPTION
I'll try to fix the test failure of "should unbind mustache templates" case in HjsTemplateTest.

## test failure
```
Failure:
HjsTemplateTest#test_should_unbind_mustache_templates [/Users/wroc/Documents/rbenv/ember-rails/test/hjstemplate_test.rb:31]:
Expected /function .*unbound|"name":"unbound"|\[\\"unbound\\"\]/m to match "Ember.TEMPLATES[\"hairy\"] = Ember.HTMLBars.template({\"id\":null,\"block\":\"{\\\"symbols\\\":[],\\\"statements\\\":[[0,\\\"This is a great \\\"],[6,\\\"img\\\"],[10,\\\"src\\\",[26,[[25,\\\"unbound\\\",[[20,[\\\"image\\\"]]],null]]]],[7],[8],[0,\\\"\\\\n\\\"]],\\\"hasEval\\\":false}\",\"meta\":{\"moduleName\":\"hairy\"}});\n".
```