### PR TITLE
Update Ruby versions on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: ruby
 sudo: false
 rvm:
   - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.10
+  - 2.3.7
+  - 2.4.3
   - jruby-9.1.5.0
 cache:
   - bundler

--- a/ember-rails.gemspec
+++ b/ember-rails.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ember-cli-assets", "~> 0.0.1"
 
   s.add_development_dependency "bundler", [">= 1.2.2"]
+  s.add_development_dependency "faraday"
   s.add_development_dependency "tzinfo"
   s.add_development_dependency "vcr"
   s.add_development_dependency "webmock"

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -19,7 +19,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   def set_test_environment
     VCR.configure do |c|
       c.cassette_library_dir = 'test/fixtures/vcr_cassettes'
-      c.hook_into :webmock # or :fakeweb
+      c.hook_into :faraday # or :webmock or :fakeweb
       c.default_cassette_options = { :record => :new_episodes }
     end
   end

--- a/test/hjstemplate_test.rb
+++ b/test/hjstemplate_test.rb
@@ -28,7 +28,7 @@ class HjsTemplateTest < IntegrationTest
     get "/assets/templates/hairy.js"
     assert_response :success
     assert_match %r{Ember\.TEMPLATES\["hairy(\.mustache)?"\] = Ember\.(?:Handlebars|HTMLBars)\.template\(}m, @response.body
-    assert_match %r{function .*unbound|"name":"unbound"|\[\\"unbound\\"\]}m, @response.body
+    assert_match %r{.*unbound|"name":"unbound"|\[\\"unbound\\"\]}m, @response.body
   end
 
   test "ensure new lines inside the anon function are persisted" do


### PR DESCRIPTION
I try to update Ruby versions on Travis CI.

However, as test errors occurred, I also addressed the following.
- Fix assert_match error of 'should unbind mustache templates' in HjsTemplateTest
- Modify VCR hook_info to faraday for InstallGeneratorTest of jruby test error